### PR TITLE
minor fix in HydroMech2D.jl miniapp

### DIFF
--- a/miniapps/HydroMech2D.jl
+++ b/miniapps/HydroMech2D.jl
@@ -196,7 +196,7 @@ end
         @printf("it = %d, time = %1.3e sec (@ T_eff = %1.2f GB/s) \n", it, wtime, round(T_eff, sigdigits=2))
         # Visualisation
         default(size=(500,700))
-        if mod(it,5)==1
+        if mod(it,5)==0
             p1 = heatmap(X, Y,  Array(Phi)'  , aspect_ratio=1, xlims=(X[1],X[end]), ylims=(Y[1],Y[end]), c=:viridis, title="porosity")
             p2 = heatmap(X, Y,  Array(Pt-Pf)', aspect_ratio=1, xlims=(X[1],X[end]), ylims=(Y[1],Y[end]), c=:viridis, title="effective pressure")
             p3 = heatmap(X, Yv, Array(qDy)'  , aspect_ratio=1, xlims=(X[1],X[end]), ylims=(Yv[1],Yv[end]), c=:viridis, title="vertical Darcy flux")

--- a/miniapps/HydroMech2D.jl
+++ b/miniapps/HydroMech2D.jl
@@ -148,8 +148,8 @@ end
     Radc     =   zeros(nx  ,ny  )
     Radc    .= [(((ix-1)*dx-0.5*lx)/λ/4.0)^2 + (((iy-1)*dy-0.25*ly)/λ)^2 for ix=1:size(Radc,1), iy=1:size(Radc,2)]
     Phi[Radc.<1.0] .= Phi[Radc.<1.0] .+ ϕA
-    EtaC     = μs./Phi.*η2μs.*0.0 .+ 1.0
-    K_muf    = k_μf0.*(Phi./ϕ0).*0.0 .+ 1.0
+    EtaC     = μs./Phi.*η2μs
+    K_muf    = k_μf0.*(Phi./ϕ0)
     ϕ0bc     = mean.(Phi[:,end])
     qDy[:,[1,end]] .= (ρsg.-ρfg).*(1.0.-ϕ0bc).*k_μf0.*(ϕ0bc./ϕ0).^nperm
     Phi      = Data.Array(Phi)

--- a/miniapps/HydroMech2D.jl
+++ b/miniapps/HydroMech2D.jl
@@ -188,7 +188,6 @@ end
         end
         dt = dt_red/(1e-10+maximum(abs.(∇V)))
         t  = t + dt
-        it+=1
         # Performance
         wtime    = Base.time()-wtime0
         A_eff    = (8*2)/1e9*nx*ny*sizeof(Data.Number)  # Effective main memory access per iteration [GB] (Lower bound of required memory access: Te has to be read and written: 2 whole-array memaccess; Ci has to be read: : 1 whole-array memaccess)
@@ -204,6 +203,7 @@ end
             p4 = heatmap(X, Yv, Array(Vy)'   , aspect_ratio=1, xlims=(X[1],X[end]), ylims=(Yv[1],Yv[end]), c=:viridis, title="vertical velocity")
             display(plot(p1, p2, p3, p4)); frame(anim)
         end
+        it+=1
     end
     gif(anim, "HydroMech2D.gif", fps = 15)
     return


### PR DESCRIPTION
1. Removed a debugging switch `... .*0.0 .+ 1.0` in the initialisation of background fields.
2. Moved the iteration counter `it+=1` to a more accurate location.