### PR TITLE
remove the CUDA.functional() error

### DIFF
--- a/src/ParallelKernel/init_parallel_kernel.jl
+++ b/src/ParallelKernel/init_parallel_kernel.jl
@@ -19,10 +19,6 @@ macro init_parallel_kernel(args...) @ArgumentError("wrong number of arguments.")
 
 function init_parallel_kernel(caller::Module, package::Symbol, numbertype::DataType; datadoc_call=:())
     if package == PKG_CUDA
-        # @assert CUDA.functional(true)
-        # if !CUDA.functional()
-        #     @warn "CUDA is not functional and likely to result in a runtime error if using ParallelStencil with the CUDA backend."
-        # end
         data_module = Data_cuda(numbertype)
         import_cmd  = :(import CUDA)
     elseif package == PKG_THREADS

--- a/src/ParallelKernel/init_parallel_kernel.jl
+++ b/src/ParallelKernel/init_parallel_kernel.jl
@@ -19,7 +19,10 @@ macro init_parallel_kernel(args...) @ArgumentError("wrong number of arguments.")
 
 function init_parallel_kernel(caller::Module, package::Symbol, numbertype::DataType; datadoc_call=:())
     if package == PKG_CUDA
-        @assert CUDA.functional(true)
+        # @assert CUDA.functional(true)
+        # if !CUDA.functional()
+        #     @warn "CUDA is not functional and likely to result in a runtime error if using ParallelStencil with the CUDA backend."
+        # end
         data_module = Data_cuda(numbertype)
         import_cmd  = :(import CUDA)
     elseif package == PKG_THREADS


### PR DESCRIPTION
The `@assert CUDA.functional(true)` currently returns an error if ParallelStencil is initialised with the CUDA GPU backend on a machine that does not have `libcuda` (no GPU available). This is problematic if ParallelStencil is used within another module and recompilation is triggered for various backends. This PR suggest to remove the `@assert CUDA.functional(true)` check. ParallelStencil can thus be initialised with the CUDA backend even if no CUDA install is available on the machine. The resulting code will fail during early runtime when CUDA.jl will try to locate `libcuda` producing a sufficient verbose error message:
```Julia-repl
┌ Error: Error during initialization of CUDA.jl
│   exception =
│    could not load library "libcuda"
│    dlopen(libcuda.dylib, 1): image not found
│    Stacktrace:
[...]
```
