### PR TITLE
Add support for CUDA 3 and skip CUDA tests when not functional

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.5.3"
 
 [compat]
 julia = "1"
-CUDA = "1, 2"
+CUDA = "1, 2, 3"
 MacroTools = "0.5"
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParallelStencil"
 uuid = "94395366-693c-11ea-3b26-d9b7aac5d958"
 authors = ["Samuel Omlin", "Ludovic Räss"]
-version = "0.5.2"
+version = "0.5.3"
 
 [compat]
 julia = "1"

--- a/test/ParallelKernel/test_allocators.jl
+++ b/test/ParallelKernel/test_allocators.jl
@@ -3,9 +3,13 @@ import ParallelStencil
 using ParallelStencil.ParallelKernel
 import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, SUPPORTED_PACKAGES, PKG_CUDA
 import ParallelStencil.ParallelKernel: @require, longnameof
-@static if (PKG_CUDA in SUPPORTED_PACKAGES) import CUDA end
+TEST_PACKAGES = SUPPORTED_PACKAGES
+@static if PKG_CUDA in TEST_PACKAGES 
+    import CUDA
+    if !CUDA.functional() TEST_PACKAGES = filter!(x->x≠PKG_CUDA, TEST_PACKAGES) end
+end
 
-@static for package in SUPPORTED_PACKAGES  eval(:(
+@static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @testset "1. allocator macros" begin
             @require !@is_initialized()

--- a/test/ParallelKernel/test_hide_communication.jl
+++ b/test/ParallelKernel/test_hide_communication.jl
@@ -5,9 +5,13 @@ import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, 
 import ParallelStencil.ParallelKernel: @require, longnameof, @prettyexpand, prettystring, @gorgeousexpand, gorgeousstring
 import ParallelStencil.ParallelKernel: checkargs_hide_communication, hide_communication, hide_communication_cuda
 using ParallelStencil.ParallelKernel.Exceptions
-@static if (PKG_CUDA in SUPPORTED_PACKAGES) import CUDA end
+TEST_PACKAGES = SUPPORTED_PACKAGES
+@static if PKG_CUDA in TEST_PACKAGES
+    import CUDA
+    if !CUDA.functional() TEST_PACKAGES = filter!(x->x≠PKG_CUDA, TEST_PACKAGES) end
+end
 
-@static for package in SUPPORTED_PACKAGES  eval(:(
+@static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @testset "1. hide_communication macro" begin
             @init_parallel_kernel($package, Float64)

--- a/test/ParallelKernel/test_init_parallel_kernel.jl
+++ b/test/ParallelKernel/test_init_parallel_kernel.jl
@@ -5,9 +5,13 @@ import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, 
 import ParallelStencil.ParallelKernel: @require, @symbols, longnameof
 import ParallelStencil.ParallelKernel: checkargs_init, check_already_initialized, set_initialized, is_initialized, check_initialized
 using ParallelStencil.ParallelKernel.Exceptions
-@static if (PKG_CUDA in SUPPORTED_PACKAGES) import CUDA end
+TEST_PACKAGES = SUPPORTED_PACKAGES
+@static if PKG_CUDA in TEST_PACKAGES
+    import CUDA
+    if !CUDA.functional() TEST_PACKAGES = filter!(x->x≠PKG_CUDA, TEST_PACKAGES) end
+end
 
-@static for package in SUPPORTED_PACKAGES  eval(:(
+@static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @testset "1. initialization of ParallelKernel" begin
             @require !@is_initialized()

--- a/test/ParallelKernel/test_parallel.jl
+++ b/test/ParallelKernel/test_parallel.jl
@@ -5,9 +5,13 @@ import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, 
 import ParallelStencil.ParallelKernel: @require, longnameof, @prettyexpand, prettystring
 import ParallelStencil.ParallelKernel: checkargs_parallel, checkargs_parallel_indices, parallel, parallel_indices, synchronize
 using ParallelStencil.ParallelKernel.Exceptions
-@static if (PKG_CUDA in SUPPORTED_PACKAGES) import CUDA end
+TEST_PACKAGES = SUPPORTED_PACKAGES
+@static if PKG_CUDA in TEST_PACKAGES
+    import CUDA
+    if !CUDA.functional() TEST_PACKAGES = filter!(x->x≠PKG_CUDA, TEST_PACKAGES) end
+end
 
-@static for package in SUPPORTED_PACKAGES  eval(:(
+@static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @testset "1. parallel macros" begin
             @init_parallel_kernel($package, Float64)

--- a/test/ParallelKernel/test_reset_parallel_kernel.jl
+++ b/test/ParallelKernel/test_reset_parallel_kernel.jl
@@ -3,9 +3,13 @@ import ParallelStencil
 using ParallelStencil.ParallelKernel
 import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, @get_package, @get_numbertype, SUPPORTED_PACKAGES, PKG_CUDA, PKG_NONE, NUMBERTYPE_NONE
 import ParallelStencil.ParallelKernel: @require, @symbols, longnameof
-@static if (PKG_CUDA in SUPPORTED_PACKAGES) import CUDA end
+TEST_PACKAGES = SUPPORTED_PACKAGES
+@static if PKG_CUDA in TEST_PACKAGES
+    import CUDA
+    if !CUDA.functional() TEST_PACKAGES = filter!(x->x≠PKG_CUDA, TEST_PACKAGES) end
+end
 
-@static for package in SUPPORTED_PACKAGES  eval(:(
+@static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @testset "1. Reset of ParallelKernel" begin
             @testset "Reset if not initialized" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@
 push!(LOAD_PATH, "../src")
 
 import ParallelStencil # Precompile it.
+import ParallelStencil: SUPPORTED_PACKAGES, PKG_CUDA
+@static if (PKG_CUDA in SUPPORTED_PACKAGES) import CUDA end
 
 excludedfiles = [ "test_excluded.jl"];
 
@@ -13,6 +15,11 @@ function runtests()
 
     nfail = 0
     printstyled("Testing package ParallelStencil.jl\n"; bold=true, color=:white)
+
+    if (PKG_CUDA in SUPPORTED_PACKAGES && !CUDA.functional())
+        @warn "Test Skip: All CUDA tests will be skipped because CUDA is not functional (if this is unexpected type `import CUDA; CUDA.functional(true)` to debug your CUDA installation)."
+    end
+
     for f in testfiles
         println("")
         if f ∈ excludedfiles
@@ -28,4 +35,5 @@ function runtests()
     end
     return nfail
 end
+
 exit(runtests())

--- a/test/test_FiniteDifferences1D.jl
+++ b/test/test_FiniteDifferences1D.jl
@@ -3,9 +3,13 @@ using ParallelStencil
 import ParallelStencil: @reset_parallel_stencil, @is_initialized, SUPPORTED_PACKAGES, PKG_CUDA, PKG_THREADS
 import ParallelStencil: @require
 using ParallelStencil.FiniteDifferences1D
-@static if (PKG_CUDA in SUPPORTED_PACKAGES) import CUDA end
+TEST_PACKAGES = SUPPORTED_PACKAGES
+@static if PKG_CUDA in TEST_PACKAGES
+    import CUDA
+    if !CUDA.functional() TEST_PACKAGES = filter!(x->x≠PKG_CUDA, TEST_PACKAGES) end
+end
 
-@static for package in SUPPORTED_PACKAGES  eval(:(
+@static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @init_parallel_stencil($package, Float64, 1)
         @require @is_initialized()

--- a/test/test_FiniteDifferences2D.jl
+++ b/test/test_FiniteDifferences2D.jl
@@ -3,9 +3,13 @@ using ParallelStencil
 import ParallelStencil: @reset_parallel_stencil, @is_initialized, SUPPORTED_PACKAGES, PKG_CUDA, PKG_THREADS
 import ParallelStencil: @require
 using ParallelStencil.FiniteDifferences2D
-@static if (PKG_CUDA in SUPPORTED_PACKAGES) import CUDA end
+TEST_PACKAGES = SUPPORTED_PACKAGES
+@static if PKG_CUDA in TEST_PACKAGES
+    import CUDA
+    if !CUDA.functional() TEST_PACKAGES = filter!(x->x≠PKG_CUDA, TEST_PACKAGES) end
+end
 
-@static for package in SUPPORTED_PACKAGES  eval(:(
+@static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @init_parallel_stencil($package, Float64, 2)
         @require @is_initialized()

--- a/test/test_FiniteDifferences3D.jl
+++ b/test/test_FiniteDifferences3D.jl
@@ -3,9 +3,13 @@ using ParallelStencil
 import ParallelStencil: @reset_parallel_stencil, @is_initialized, SUPPORTED_PACKAGES, PKG_CUDA, PKG_THREADS
 import ParallelStencil: @require
 using ParallelStencil.FiniteDifferences3D
-@static if (PKG_CUDA in SUPPORTED_PACKAGES) import CUDA end
+TEST_PACKAGES = SUPPORTED_PACKAGES
+@static if PKG_CUDA in TEST_PACKAGES
+    import CUDA
+    if !CUDA.functional() TEST_PACKAGES = filter!(x->x≠PKG_CUDA, TEST_PACKAGES) end
+end
 
-@static for package in SUPPORTED_PACKAGES eval(:(
+@static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @init_parallel_stencil($package, Float64, 3)
         @require @is_initialized()

--- a/test/test_incremental_compilation.jl
+++ b/test/test_incremental_compilation.jl
@@ -3,9 +3,13 @@ push!(LOAD_PATH, joinpath(@__DIR__, ".."))
 using Test
 using Pkg
 import ParallelStencil: SUPPORTED_PACKAGES, PKG_CUDA
-@static if (PKG_CUDA in SUPPORTED_PACKAGES) import CUDA end
+TEST_PACKAGES = SUPPORTED_PACKAGES
+@static if PKG_CUDA in TEST_PACKAGES
+    import CUDA
+    if !CUDA.functional() TEST_PACKAGES = filter!(x->x≠PKG_CUDA, TEST_PACKAGES) end
+end
 
-@static for package in SUPPORTED_PACKAGES  eval(:(
+@static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @testset "incremental compilation" begin
             Pkg.activate(joinpath(@__DIR__, "test_projects", "Diffusion3D_$(nameof($package))"))

--- a/test/test_init_parallel_stencil.jl
+++ b/test/test_init_parallel_stencil.jl
@@ -4,9 +4,13 @@ import ParallelStencil: @reset_parallel_stencil, @is_initialized, @get_package, 
 import ParallelStencil: @require, @symbols, longnameof
 import ParallelStencil: checkargs_init, check_already_initialized, set_initialized, is_initialized, check_initialized, set_package, set_numbertype, set_ndims
 using ParallelStencil.Exceptions
-@static if (PKG_CUDA in SUPPORTED_PACKAGES) import CUDA end
+TEST_PACKAGES = SUPPORTED_PACKAGES
+@static if PKG_CUDA in TEST_PACKAGES
+    import CUDA
+    if !CUDA.functional() TEST_PACKAGES = filter!(x->x≠PKG_CUDA, TEST_PACKAGES) end
+end
 
-@static for package in SUPPORTED_PACKAGES  eval(:(
+@static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @testset "1. initialization of ParallelStencil" begin
             @require !@is_initialized()

--- a/test/test_parallel.jl
+++ b/test/test_parallel.jl
@@ -5,10 +5,14 @@ import ParallelStencil: @require, longnameof, @prettyexpand, prettystring
 import ParallelStencil: checkargs_parallel, validate_body, parallel
 using ParallelStencil.Exceptions
 using ParallelStencil.FiniteDifferences3D
-@static if (PKG_CUDA in SUPPORTED_PACKAGES) import CUDA end
 ix, iy, iz = INDICES[1], INDICES[2], INDICES[3]
+TEST_PACKAGES = SUPPORTED_PACKAGES
+@static if PKG_CUDA in TEST_PACKAGES
+    import CUDA
+    if !CUDA.functional() TEST_PACKAGES = filter!(x->x≠PKG_CUDA, TEST_PACKAGES) end
+end
 
-@static for package in SUPPORTED_PACKAGES  eval(:(
+@static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @testset "1. parallel macros" begin
             @init_parallel_stencil($package, Float64, 3)

--- a/test/test_reset_parallel_stencil.jl
+++ b/test/test_reset_parallel_stencil.jl
@@ -2,9 +2,13 @@ using Test
 using ParallelStencil
 import ParallelStencil: @reset_parallel_stencil, @is_initialized, @get_package, @get_numbertype, @get_ndims, SUPPORTED_PACKAGES, PKG_CUDA, PKG_NONE, NUMBERTYPE_NONE, NDIMS_NONE
 import ParallelStencil: @require, @symbols, longnameof
-@static if (PKG_CUDA in SUPPORTED_PACKAGES) import CUDA end
+TEST_PACKAGES = SUPPORTED_PACKAGES
+@static if PKG_CUDA in TEST_PACKAGES
+    import CUDA
+    if !CUDA.functional() TEST_PACKAGES = filter!(x->x≠PKG_CUDA, TEST_PACKAGES) end
+end
 
-@static for package in SUPPORTED_PACKAGES  eval(:(
+@static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @testset "1. Reset of ParallelStencil" begin
             @testset "Reset if not initialized" begin


### PR DESCRIPTION
Fixes #23 
Fixes #22 

Gives a warning in runtest.jl if CUDA is not functional and CUDA tests will have to be skipped.