### PR TITLE
Fix, improve and unify all unit tests

### DIFF
--- a/src/ParallelKernel/shared.jl
+++ b/src/ParallelKernel/shared.jl
@@ -160,6 +160,8 @@ macro prettyexpand(n::Integer, expr)   return QuoteNode(remove_linenumbernodes!(
 macro gorgeousexpand(n::Integer, expr) return QuoteNode(simplify_varnames!(remove_linenumbernodes!(macroexpandn(__module__, expr, n)))) end
 macro prettyexpand(expr)               return QuoteNode(remove_linenumbernodes!(macroexpand(__module__, expr; recursive=true))) end
 macro gorgeousexpand(expr)             return QuoteNode(simplify_varnames!(remove_linenumbernodes!(macroexpand(__module__, expr; recursive=true)))) end
+macro prettystring(args...)            return esc(:(string(ParallelStencil.ParallelKernel.@prettyexpand($(args...))))) end
+macro gorgeousstring(args...)          return esc(:(string(ParallelStencil.ParallelKernel.@gorgeousexpand($(args...))))) end
 
 function macroexpandn(m::Module, expr, n::Integer)
     for i = 1:n

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -5,7 +5,7 @@ import .ParallelKernel: ENABLE_CUDA  # ENABLE_CUDA must also always be accessibl
 end
 import .ParallelKernel: checkargs_init, check_numbertype, eval_arg, is_function, is_call, gensym_world
 import .ParallelKernel: PKG_CUDA, PKG_THREADS, PKG_NONE, NUMBERTYPE_NONE, SUPPORTED_NUMBERTYPES, SUPPORTED_PACKAGES, ERRMSG_UNSUPPORTED_PACKAGE, INT_CUDA, INT_THREADS, INDICES
-import .ParallelKernel: @require, @symbols, symbols, longnameof, @prettyexpand, prettystring, @gorgeousexpand, gorgeousstring
+import .ParallelKernel: @require, @symbols, symbols, longnameof, @prettyexpand, @prettystring, prettystring, @gorgeousexpand, @gorgeousstring, gorgeousstring
 
 
 ## CONSTANTS

--- a/test/ParallelKernel/test_allocators.jl
+++ b/test/ParallelKernel/test_allocators.jl
@@ -2,9 +2,9 @@ using Test
 import ParallelStencil
 using ParallelStencil.ParallelKernel
 import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, SUPPORTED_PACKAGES, PKG_CUDA
-import ParallelStencil.ParallelKernel: @require, longnameof
+import ParallelStencil.ParallelKernel: @require
 TEST_PACKAGES = SUPPORTED_PACKAGES
-@static if PKG_CUDA in TEST_PACKAGES 
+@static if PKG_CUDA in TEST_PACKAGES
     import CUDA
     if !CUDA.functional() TEST_PACKAGES = filter!(x->x≠PKG_CUDA, TEST_PACKAGES) end
 end
@@ -14,11 +14,11 @@ end
         @testset "1. allocator macros" begin
             @require !@is_initialized()
             @init_parallel_kernel($package, Float16)
+            @require @is_initialized()
             @testset "mapping to package" begin
-                @require @is_initialized()
                 @test @zeros(2,3) == parentmodule($package).zeros(Float16,2,3)
                 @test @ones(2,3) == parentmodule($package).ones(Float16,2,3)
-                @static if $package == CUDA
+                @static if $package == $PKG_CUDA
                     @test typeof(@rand(2,3)) == typeof(CUDA.CuArray(rand(Float16,2,3)))
                 else
                     @test typeof(@rand(2,3)) == typeof(parentmodule($package).rand(Float16,2,3))

--- a/test/ParallelKernel/test_hide_communication.jl
+++ b/test/ParallelKernel/test_hide_communication.jl
@@ -2,8 +2,8 @@ using Test
 import ParallelStencil
 using ParallelStencil.ParallelKernel
 import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, SUPPORTED_PACKAGES, PKG_CUDA, PKG_THREADS
-import ParallelStencil.ParallelKernel: @require, longnameof, @prettyexpand, prettystring, @gorgeousexpand, gorgeousstring
-import ParallelStencil.ParallelKernel: checkargs_hide_communication, hide_communication, hide_communication_cuda
+import ParallelStencil.ParallelKernel: @require, @prettyexpand, @gorgeousexpand, gorgeousstring
+import ParallelStencil.ParallelKernel: checkargs_hide_communication, hide_communication_cuda
 using ParallelStencil.ParallelKernel.Exceptions
 TEST_PACKAGES = SUPPORTED_PACKAGES
 @static if PKG_CUDA in TEST_PACKAGES
@@ -14,6 +14,7 @@ end
 @static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @testset "1. hide_communication macro" begin
+            @require !@is_initialized()
             @init_parallel_kernel($package, Float64)
             @require @is_initialized()
             @testset "@hide_communication boundary_width block (macro expansion)" begin
@@ -25,7 +26,6 @@ end
                 end;
             end;
             @testset "@hide_communication" begin
-                @require @is_initialized()
                 @parallel_indices (ix,iy,iz) function add_indices!(A)
                     A[ix,iy,iz] = A[ix,iy,iz] + ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2); # NOTE: $ix, $iy, $iz come from ParallelStencil.INDICES.
                     return
@@ -99,6 +99,7 @@ end
             @reset_parallel_kernel()
         end;
         @testset "2. Exceptions" begin
+            @require !@is_initialized()
             @init_parallel_kernel($package, Float64)
             @require @is_initialized
             @testset "arguments @hide_communication" begin

--- a/test/ParallelKernel/test_init_parallel_kernel.jl
+++ b/test/ParallelKernel/test_init_parallel_kernel.jl
@@ -2,7 +2,7 @@ using Test
 import ParallelStencil
 using ParallelStencil.ParallelKernel
 import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, @get_package, @get_numbertype, SUPPORTED_PACKAGES, PKG_CUDA
-import ParallelStencil.ParallelKernel: @require, @symbols, longnameof
+import ParallelStencil.ParallelKernel: @require, @symbols
 import ParallelStencil.ParallelKernel: checkargs_init, check_already_initialized, set_initialized, is_initialized, check_initialized
 using ParallelStencil.ParallelKernel.Exceptions
 TEST_PACKAGES = SUPPORTED_PACKAGES

--- a/test/ParallelKernel/test_kernel_language.jl
+++ b/test/ParallelKernel/test_kernel_language.jl
@@ -2,8 +2,8 @@ using Test
 import ParallelStencil
 using ParallelStencil.ParallelKernel
 import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, SUPPORTED_PACKAGES, PKG_CUDA, PKG_THREADS
-import ParallelStencil.ParallelKernel: @require, longnameof, @prettyexpand, prettystring
-import ParallelStencil.ParallelKernel: checknoargs, checkargs_sharedMem, gridDim, blockIdx, blockDim, threadIdx, sync_threads, sharedMem, pk_show, pk_println, Dim3
+import ParallelStencil.ParallelKernel: @require, @prettystring
+import ParallelStencil.ParallelKernel: checknoargs, checkargs_sharedMem, Dim3
 using ParallelStencil.ParallelKernel.Exceptions
 TEST_PACKAGES = SUPPORTED_PACKAGES
 @static if PKG_CUDA in TEST_PACKAGES
@@ -14,31 +14,32 @@ end
 @static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @testset "1. kernel language macros" begin
-            @init_parallel_kernel($package, Float64)
-            @require @is_initialized()
             @testset "mapping to package" begin
-                @static if $package == PKG_CUDA
-                    @test prettystring(gridDim()) == "CUDA.gridDim()"
-                    @test prettystring(blockIdx()) == "CUDA.blockIdx()"
-                    @test prettystring(blockDim()) == "CUDA.blockDim()"
-                    @test prettystring(threadIdx()) == "CUDA.threadIdx()"
-                    @test prettystring(sync_threads()) == "CUDA.sync_threads()"
-                    @test prettystring(sharedMem()) == "CUDA.@cuDynamicSharedMem"
-                    @test prettystring(pk_show()) == "CUDA.@cushow"
-                    @test prettystring(pk_println()) == "CUDA.@cuprintln"
-                elseif $package == PKG_THREADS
-                    @test prettystring(gridDim()) == "ParallelStencil.ParallelKernel.@gridDim_cpu"
-                    @test prettystring(blockIdx()) == "ParallelStencil.ParallelKernel.@blockIdx_cpu"
-                    @test prettystring(blockDim()) == "ParallelStencil.ParallelKernel.@blockDim_cpu"
-                    @test prettystring(threadIdx()) == "ParallelStencil.ParallelKernel.@threadIdx_cpu"
-                    @test prettystring(sync_threads()) == "ParallelStencil.ParallelKernel.@sync_threads_cpu"
-                    @test prettystring(sharedMem()) == "ParallelStencil.ParallelKernel.@sharedMem_cpu"
-                    @test prettystring(pk_show()) == "Base.@show"
-                    @test prettystring(pk_println()) == "Base.@println"
+                @require !@is_initialized()
+                @init_parallel_kernel($package, Float64)
+                @require @is_initialized()
+                if $package == $PKG_CUDA
+                    @test @prettystring(1, @gridDim()) == "CUDA.gridDim()"
+                    @test @prettystring(1, @blockIdx()) == "CUDA.blockIdx()"
+                    @test @prettystring(1, @blockDim()) == "CUDA.blockDim()"
+                    @test @prettystring(1, @threadIdx()) == "CUDA.threadIdx()"
+                    @test @prettystring(1, @sync_threads()) == "CUDA.sync_threads()"
+                    @test @prettystring(1, @sharedMem(Float32, (2,3))) == "CUDA.@cuDynamicSharedMem Float32 (2, 3)"
+                    @test @prettystring(1, @pk_show()) == "CUDA.@cushow"
+                    @test @prettystring(1, @pk_println()) == "CUDA.@cuprintln"
+                elseif $package == $PKG_THREADS
+                    @test @prettystring(1, @gridDim()) == "ParallelStencil.ParallelKernel.@gridDim_cpu"
+                    @test @prettystring(1, @blockIdx()) == "ParallelStencil.ParallelKernel.@blockIdx_cpu"
+                    @test @prettystring(1, @blockDim()) == "ParallelStencil.ParallelKernel.@blockDim_cpu"
+                    @test @prettystring(1, @threadIdx()) == "ParallelStencil.ParallelKernel.@threadIdx_cpu"
+                    @test @prettystring(1, @sync_threads()) == "ParallelStencil.ParallelKernel.@sync_threads_cpu"
+                    @test @prettystring(1, @sharedMem(Float32, (2,3))) == "ParallelStencil.ParallelKernel.@sharedMem_cpu Float32 (2, 3)"
+                    @test @prettystring(1, @pk_show()) == "Base.@show"
+                    @test @prettystring(1, @pk_println()) == "Base.@println"
                 end;
             end;
             @testset "@gridDim, @blockIdx, @blockDim, @threadIdx (1D)" begin
-                @static if $package == PKG_THREADS
+                @static if $package == $PKG_THREADS
                     A  = @zeros(4)
                     @parallel_indices (ix) function test_macros!(A)
                         @test @gridDim() == Dim3(2, 1, 1)
@@ -48,10 +49,14 @@ end
                         return
                     end
                     @parallel (3:4) test_macros!(A);
+                    @test true # @gridDim test succeeded if this line is reached (the above tests within the kernel are not captured if they succeed, only if they fail...; alternative test implementations would be of course possible, but would be more complex).
+                    @test true # @blockIdx ...
+                    @test true # @blockDim ...
+                    @test true # @threadIdx ...
                 end
             end;
             @testset "@gridDim, @blockIdx, @blockDim, @threadIdx (2D)" begin
-                @static if $package == PKG_THREADS
+                @static if $package == $PKG_THREADS
                     A  = @zeros(4, 5)
                     @parallel_indices (ix,iy) function test_macros!(A)
                         @test @gridDim() == Dim3(2, 3, 1)
@@ -61,10 +66,14 @@ end
                         return
                     end
                     @parallel (3:4, 2:4) test_macros!(A);
+                    @test true # @gridDim test succeeded if this line is reached (the above tests within the kernel are not captured if they succeed, only if they fail...; alternative test implementations would be of course possible, but would be more complex).
+                    @test true # @blockIdx ...
+                    @test true # @blockDim ...
+                    @test true # @threadIdx ...
                 end
             end;
             @testset "@gridDim, @blockIdx, @blockDim, @threadIdx (3D)" begin
-                @static if $package == PKG_THREADS
+                @static if $package == $PKG_THREADS
                     A  = @zeros(4, 5, 6)
                     @parallel_indices (ix,iy,iz) function test_macros!(A)
                         @test @gridDim() == Dim3(2, 3, 6)
@@ -74,21 +83,25 @@ end
                         return
                     end
                     @parallel (3:4, 2:4, 1:6) test_macros!(A);
+                    @test true # @gridDim test succeeded if this line is reached (the above tests within the kernel are not captured if they succeed, only if they fail...; alternative test implementations would be of course possible, but would be more complex).
+                    @test true # @blockIdx ...
+                    @test true # @blockDim ...
+                    @test true # @threadIdx ...
                 end
             end;
             @testset "sync_threads" begin
-                @static if $package == PKG_THREADS
-                    @test string(@prettyexpand ParallelStencil.ParallelKernel.@sync_threads_cpu()) == "begin\nend"
+                @static if $package == $PKG_THREADS
+                    @test @prettystring(ParallelStencil.ParallelKernel.@sync_threads_cpu()) == "begin\nend"
                 end;
             end;
             @testset "shared memory (allocation)" begin
-                @static if $package == PKG_THREADS
+                @static if $package == $PKG_THREADS
                     @test typeof(@sharedMem(Float32,(2,3))) == typeof(ParallelStencil.ParallelKernel.MArray{Tuple{2,3},   Float32, length((2,3)),   prod((2,3))}(undef))
                     @test typeof(@sharedMem(Bool,(2,3,4)))  == typeof(ParallelStencil.ParallelKernel.MArray{Tuple{2,3,4}, Bool,    length((2,3,4)), prod((2,3,4))}(undef))
                 end;
             end;
             @testset "@sharedMem (1D)" begin
-                @static if $package == PKG_THREADS
+                @static if $package == $PKG_THREADS
                     A  = @rand(4)
                     B  = @zeros(4)
                     @parallel_indices (ix) function memcopy!(B, A)
@@ -104,7 +117,7 @@ end
                 end
             end;
             @testset "@sharedMem (2D)" begin
-                @static if $package == PKG_THREADS
+                @static if $package == $PKG_THREADS
                     A  = @rand(4,5)
                     B  = @zeros(4,5)
                     @parallel_indices (ix,iy) function memcopy!(B, A)
@@ -121,7 +134,7 @@ end
                 end
             end;
             @testset "@sharedMem (3D)" begin
-                @static if $package == PKG_THREADS
+                @static if $package == $PKG_THREADS
                     A  = @rand(4,5,6)
                     B  = @zeros(4,5,6)
                     @parallel_indices (ix,iy,iz) function memcopy!(B, A)
@@ -144,12 +157,12 @@ end
             @init_parallel_kernel($package, Float64)
             @require @is_initialized
             @testset "no arguments" begin
-                @test_throws ArgumentError checknoargs(:(something));                                                       # Error: length(args) != 0
+                @test_throws ArgumentError checknoargs(:(something));                                      # Error: length(args) != 0
             end;
             @testset "arguments @sharedMem" begin
-                @test_throws ArgumentError checkargs_sharedMem();                                                   # Error: isempty(args)
-                @test_throws ArgumentError checkargs_sharedMem(:(something));                                       # Error: length(args) != 2
-                @test_throws ArgumentError checkargs_sharedMem(:(something), :(something), :(something));           # Error: length(args) != 2
+                @test_throws ArgumentError checkargs_sharedMem();                                          # Error: isempty(args)
+                @test_throws ArgumentError checkargs_sharedMem(:(something));                              # Error: length(args) != 2
+                @test_throws ArgumentError checkargs_sharedMem(:(something), :(something), :(something));  # Error: length(args) != 2
             end;
             @reset_parallel_kernel()
         end;

--- a/test/ParallelKernel/test_reset_parallel_kernel.jl
+++ b/test/ParallelKernel/test_reset_parallel_kernel.jl
@@ -2,7 +2,7 @@ using Test
 import ParallelStencil
 using ParallelStencil.ParallelKernel
 import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, @get_package, @get_numbertype, SUPPORTED_PACKAGES, PKG_CUDA, PKG_NONE, NUMBERTYPE_NONE
-import ParallelStencil.ParallelKernel: @require, @symbols, longnameof
+import ParallelStencil.ParallelKernel: @require, @symbols
 TEST_PACKAGES = SUPPORTED_PACKAGES
 @static if PKG_CUDA in TEST_PACKAGES
     import CUDA

--- a/test/test_FiniteDifferences1D.jl
+++ b/test/test_FiniteDifferences1D.jl
@@ -11,6 +11,7 @@ end
 
 @static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
+        @require !@is_initialized()
         @init_parallel_stencil($package, Float64, 1)
         @require @is_initialized()
         nx  = 7
@@ -21,33 +22,28 @@ end
         Rxx = @zeros(nx+2);
         @testset "1. compute macros" begin
             @testset "differences" begin
-                @require @is_initialized()
                 @parallel d!(R, Ax) = (@all(R) = @d(Ax); return)
                 @parallel d2!(R, Axx) = (@all(R) = @d2(Axx); return)
                 R.=0; @parallel d!(R, Ax);  @test all(R .== Ax[2:end].-Ax[1:end-1])
                 R.=0; @parallel d2!(R, Axx);  @test all(R .== (Axx[3:end].-Axx[2:end-1]).-(Axx[2:end-1].-Axx[1:end-2]))
             end;
             @testset "selection" begin
-                @require @is_initialized()
                 @parallel all!(R, A) = (@all(R) = @all(A); return)
                 @parallel inn!(R, Axx) = (@all(R) = @inn(Axx); return)
                 R.=0; @parallel all!(R, A);  @test all(R .== A)
                 R.=0; @parallel inn!(R, Axx);  @test all(R .== Axx[2:end-1])
             end;
             @testset "averages" begin
-                @require @is_initialized()
                 @parallel av!(R, Ax) = (@all(R) = @av(Ax); return)
                 R.=0; @parallel av!(R, Ax);  @test all(R .== (Ax[1:end-1].+Ax[2:end]).*0.5)
             end;
             @testset "others" begin
-                @require @is_initialized()
                 @parallel maxloc!(R, Axx) = (@all(R) = @maxloc(Axx); return)
                 R.=0; @parallel maxloc!(R, Axx);  @test all(R .== max.(max.(Axx[3:end],Axx[2:end-1]),Axx[1:end-2]))
             end;
         end;
         @testset "2. apply masks" begin
             @testset "selection" begin
-                @require @is_initialized()
                 @parallel inn_all!(Rxx, A) = (@inn(Rxx) = @all(A); return)
                 @parallel inn_inn!(Rxx, Axx) = (@inn(Rxx) = @inn(Axx); return)
                 Rxx.=0; @parallel inn_all!(Rxx, A);  @test all(Rxx[2:end-1] .== A)
@@ -56,7 +52,6 @@ end
                 Rxx[2:end-1].=0; @test all(Rxx .== 0)  # Test that boundary values remained zero.
             end;
             @testset "differences" begin
-                @require @is_initialized()
                 @parallel inn_d!(Rxx, Ax) = (@inn(Rxx) = @d(Ax); return)
                 @parallel inn_d2!(Rxx, Axx) = (@inn(Rxx) = @d2(Axx); return)
                 Rxx.=0; @parallel inn_d!(Rxx, Ax);  @test all(Rxx[2:end-1] .== Ax[2:end].-Ax[1:end-1])

--- a/test/test_init_parallel_stencil.jl
+++ b/test/test_init_parallel_stencil.jl
@@ -1,7 +1,7 @@
 using Test
 using ParallelStencil
 import ParallelStencil: @reset_parallel_stencil, @is_initialized, @get_package,  @get_numbertype, @get_ndims, SUPPORTED_PACKAGES, PKG_CUDA, PKG_NONE, NUMBERTYPE_NONE, NDIMS_NONE
-import ParallelStencil: @require, @symbols, longnameof
+import ParallelStencil: @require, @symbols
 import ParallelStencil: checkargs_init, check_already_initialized, set_initialized, is_initialized, check_initialized, set_package, set_numbertype, set_ndims
 using ParallelStencil.Exceptions
 TEST_PACKAGES = SUPPORTED_PACKAGES

--- a/test/test_parallel.jl
+++ b/test/test_parallel.jl
@@ -1,7 +1,7 @@
 using Test
 using ParallelStencil
 import ParallelStencil: @reset_parallel_stencil, @is_initialized, SUPPORTED_PACKAGES, PKG_CUDA, PKG_THREADS, INDICES
-import ParallelStencil: @require, longnameof, @prettyexpand, prettystring
+import ParallelStencil: @require, @prettystring
 import ParallelStencil: checkargs_parallel, validate_body, parallel
 using ParallelStencil.Exceptions
 using ParallelStencil.FiniteDifferences3D
@@ -15,31 +15,31 @@ end
 @static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
         @testset "1. parallel macros" begin
+            @require !@is_initialized()
             @init_parallel_stencil($package, Float64, 3)
             @require @is_initialized()
-            @testset "@parallel kernelcall" begin # NOTE: calls must go to ParallelStencil.ParallelKernel.parallel and must therefore give the same result as in ParallelKernel (tests copied from there).
-                @static if $package == PKG_CUDA
-                    call = prettystring(parallel(:(f(A))))
-                    @test occursin("CUDA.@cuda blocks = ParallelStencil.ParallelKernel.compute_nblocks(length.(ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A))), ParallelStencil.ParallelKernel.compute_nthreads(length.(ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A))))) threads = ParallelStencil.ParallelKernel.compute_nthreads(length.(ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))) f(A, ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))", call)
+            @testset "@parallel kernelcall" begin # NOTE: calls must go to ParallelStencil.ParallelKernel.parallel and must therefore give the same result as in ParallelKernel (tests copied 1-to-1 from there).
+                @static if $package == $PKG_CUDA
+                    call = @prettystring(1, @parallel f(A))
+                    @test occursin("CUDA.@cuda blocks = ParallelStencil.ParallelKernel.compute_nblocks(length.(ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A))), ParallelStencil.ParallelKernel.compute_nthreads(length.(ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A))))) threads = ParallelStencil.ParallelKernel.compute_nthreads(length.(ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))) f(A, ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))[1])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))[2])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))[3])))", call)
                     @test occursin("CUDA.synchronize()", call)
-                    call = prettystring(parallel(:ranges, :(f(A))))
-                    @test occursin("CUDA.@cuda blocks = ParallelStencil.ParallelKernel.compute_nblocks(length.(ParallelStencil.ParallelKernel.promote_ranges(ranges)), ParallelStencil.ParallelKernel.compute_nthreads(length.(ParallelStencil.ParallelKernel.promote_ranges(ranges)))) threads = ParallelStencil.ParallelKernel.compute_nthreads(length.(ParallelStencil.ParallelKernel.promote_ranges(ranges))) f(A, ParallelStencil.ParallelKernel.promote_ranges(ranges))", call)
-                    call = prettystring(parallel(:nblocks, :nthreads, :(f(A))))
-                    @test occursin("CUDA.@cuda blocks = nblocks threads = nthreads f(A, ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)))", call)
-                    call = prettystring(parallel(:ranges, :nblocks, :nthreads, :(f(A))))
-                    @test occursin("CUDA.@cuda blocks = nblocks threads = nthreads f(A, ParallelStencil.ParallelKernel.promote_ranges(ranges))", call)
-                    call = prettystring(parallel(:nblocks, :nthreads, :(stream=mystream), :(f(A))))
-                    @test occursin("CUDA.@cuda blocks = nblocks threads = nthreads stream = mystream f(A, ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)))", call)
-                elseif $package == PKG_THREADS
-                    @test prettystring(parallel(:(f(A)))) == "f(A, ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))"
-                    @test prettystring(parallel(:ranges, :(f(A)))) == "f(A, ParallelStencil.ParallelKernel.promote_ranges(ranges))"
-                    @test prettystring(parallel(:nblocks, :nthreads, :(f(A)))) == "f(A, ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)))"
-                    @test prettystring(parallel(:ranges, :nblocks, :nthreads, :(f(A)))) == "f(A, ParallelStencil.ParallelKernel.promote_ranges(ranges))"
-                    @test prettystring(parallel(:(stream=mystream), :(f(A)))) == "f(A, ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))"
+                    call = @prettystring(1, @parallel ranges f(A))
+                    @test occursin("CUDA.@cuda blocks = ParallelStencil.ParallelKernel.compute_nblocks(length.(ParallelStencil.ParallelKernel.promote_ranges(ranges)), ParallelStencil.ParallelKernel.compute_nthreads(length.(ParallelStencil.ParallelKernel.promote_ranges(ranges)))) threads = ParallelStencil.ParallelKernel.compute_nthreads(length.(ParallelStencil.ParallelKernel.promote_ranges(ranges))) f(A, ParallelStencil.ParallelKernel.promote_ranges(ranges), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ranges))[1])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ranges))[2])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ranges))[3])))", call)
+                    call = @prettystring(1, @parallel nblocks nthreads f(A))
+                    @test occursin("CUDA.@cuda blocks = nblocks threads = nthreads f(A, ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)))[1])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)))[2])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)))[3])))", call)
+                    call = @prettystring(1, @parallel ranges nblocks nthreads f(A))
+                    @test occursin("CUDA.@cuda blocks = nblocks threads = nthreads f(A, ParallelStencil.ParallelKernel.promote_ranges(ranges), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ranges))[1])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ranges))[2])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ranges))[3])))", call)
+                    call = @prettystring(1, @parallel nblocks nthreads stream=mystream f(A))
+                    @test occursin("CUDA.@cuda blocks = nblocks threads = nthreads stream = mystream f(A, ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)))[1])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)))[2])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)))[3])))", call)
+                elseif $package == $PKG_THREADS
+                    @test @prettystring(1, @parallel f(A)) == "f(A, ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))[1])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))[2])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))[3])))"
+                    @test @prettystring(1, @parallel ranges f(A)) == "f(A, ParallelStencil.ParallelKernel.promote_ranges(ranges), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ranges))[1])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ranges))[2])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ranges))[3])))"
+                    @test @prettystring(1, @parallel nblocks nthreads f(A)) == "f(A, ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)))[1])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)))[2])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.compute_ranges(nblocks .* nthreads)))[3])))"
+                    @test @prettystring(1, @parallel ranges nblocks nthreads f(A)) == "f(A, ParallelStencil.ParallelKernel.promote_ranges(ranges), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ranges))[1])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ranges))[2])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ranges))[3])))"
+                    @test @prettystring(1, @parallel stream=mystream f(A)) == "f(A, ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))[1])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))[2])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))[3])))"
                 end;
             end;
             @testset "@parallel kernel" begin
-                @require @is_initialized()
                 A  = @zeros(4, 5, 6)
                 @parallel function write_indices!(A)
                     @all(A) = $ix + ($iy-1)*size(A,1) + ($iz-1)*size(A,1)*size(A,2); # NOTE: $ix, $iy, $iz come from ParallelStencil.INDICES.
@@ -49,10 +49,9 @@ end
                 @test all(Array(A) .== [ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2) for ix=1:size(A,1), iy=1:size(A,2), iz=1:size(A,3)])
             end;
             @testset "apply masks" begin
-                @require @is_initialized()
-                expansion = string(@prettyexpand 1 @parallel sum!(A, B) = (@all(A) = @all(A) + @all(B); return))
+                expansion = @prettystring(1, @parallel sum!(A, B) = (@all(A) = @all(A) + @all(B); return))
                 @test occursin("if @within(\"@all\", A)", expansion)
-                @test string(@prettyexpand @within("@all", A)) == string(:($ix <= size(A, 1) && ($iy <= size(A, 2) && $iz <= size(A, 3))))
+                @test @prettystring(@within("@all", A)) == string(:($ix <= size(A, 1) && ($iy <= size(A, 2) && $iz <= size(A, 3))))
             end;
             @reset_parallel_stencil()
         end;

--- a/test/test_reset_parallel_stencil.jl
+++ b/test/test_reset_parallel_stencil.jl
@@ -1,7 +1,7 @@
 using Test
 using ParallelStencil
 import ParallelStencil: @reset_parallel_stencil, @is_initialized, @get_package, @get_numbertype, @get_ndims, SUPPORTED_PACKAGES, PKG_CUDA, PKG_NONE, NUMBERTYPE_NONE, NDIMS_NONE
-import ParallelStencil: @require, @symbols, longnameof
+import ParallelStencil: @require, @symbols
 TEST_PACKAGES = SUPPORTED_PACKAGES
 @static if PKG_CUDA in TEST_PACKAGES
     import CUDA


### PR DESCRIPTION
Some unit tests were not executed.

**Unit test launch status before fix (launched/avail for Threads, for CUDA):**
ParallelKernel:

1. allocators: (3/3, 3/3)
2. pk-init: (12/12, 12/12)
3. pk-reset: (7/7, 7/7)
4. hide_comm: (6/6, 31/31)
5. **pk-parallel: (25/30, 25/33)**
6. **kernel_language (4/30, 4/12)**

ParallelStencil:

1. ps-init (16/16, 16/16)
2. ps-reset (9/9, 9/9)
3. incremental comp (1/1, 1/1)
4. FD 1-D (14/14, 14/14)
5. FD 2-D (26/26, 26/26)
6. FD 3-D (41/41, 41/41)
7. **ps-parallel (11/16, 11/17)**

**Unit test launch status after fix (launched/avail for Threads, for CUDA):**

ParallelKernel:

1. allocators: (3/3, 3/3)
2. pk-init: (12/12, 12/12)
3. pk-reset: (7/7, 7/7)
4. hide_comm: (6/6, 31/31)
5. **pk-parallel: (30/30, 33/33)**
6. **kernel_language (30/30, 12/12)**

ParallelStencil:

1. ps-init (16/16, 16/16)
2. ps-reset (9/9, 9/9)
3. incremental comp (1/1, 1/1)
4. FD 1-D (14/14, 14/14)
5. FD 2-D (26/26, 26/26)
6. FD 3-D (41/41, 41/41)
7. **ps-parallel (16/16, 17/17)**