### PR TITLE
Support numbertype omission in ParallelStencil initialization

### DIFF
--- a/examples/diffusion3D_multigpucpu_hidecomm_parindices_novis.jl
+++ b/examples/diffusion3D_multigpucpu_hidecomm_parindices_novis.jl
@@ -1,6 +1,5 @@
 const USE_GPU = true
 using ImplicitGlobalGrid
-import MPI
 using ParallelStencil
 @static if USE_GPU
     @init_parallel_stencil(CUDA, Float64, 3);

--- a/examples/parametrized/diffusion3D_multigpucpu_novis.jl
+++ b/examples/parametrized/diffusion3D_multigpucpu_novis.jl
@@ -1,6 +1,5 @@
 const USE_GPU = true
 using ImplicitGlobalGrid
-import MPI
 using ParallelStencil
 using ParallelStencil.FiniteDifferences3D
 @static if USE_GPU
@@ -9,12 +8,12 @@ else
     @init_parallel_stencil(package=Threads, ndims=3);
 end
 
-@parallel function diffusion3D_step!(T2::Data.Array{_T}, T::Data.Array{_T}, Ci::Data.Array{_T}, lam::_T, dt::_T, _dx::_T, _dy::_T, _dz::_T) where _T <: ParallelStencil.PSNumber
+@parallel function diffusion3D_step!(T2::Data.Array{_T}, T::Data.Array{_T}, Ci::Data.Array{_T}, lam::_T, dt::_T, _dx::_T, _dy::_T, _dz::_T) where _T <: PSNumber
     @inn(T2) = @inn(T) + dt*(lam*@inn(Ci)*(@d2_xi(T)*_dx^2 + @d2_yi(T)*_dy^2 + @d2_zi(T)*_dz^2));
     return
 end
 
-function diffusion3D(lam::_T, c0::_T, lx::_T, ly::_T, lz::_T) where _T <: ParallelStencil.PSNumber
+function diffusion3D(lam::_T, c0::_T, lx::_T, ly::_T, lz::_T) where _T <: PSNumber
 
 # Numerics
 nx, ny, nz = 512, 512, 512;                              # Number of gridpoints in dimensions x, y and z

--- a/examples/parametrized/diffusion3D_multigpucpu_novis.jl
+++ b/examples/parametrized/diffusion3D_multigpucpu_novis.jl
@@ -1,0 +1,69 @@
+const USE_GPU = true
+using ImplicitGlobalGrid
+import MPI
+using ParallelStencil
+using ParallelStencil.FiniteDifferences3D
+@static if USE_GPU
+    @init_parallel_stencil(package=CUDA, ndims=3);
+else
+    @init_parallel_stencil(package=Threads, ndims=3);
+end
+
+@parallel function diffusion3D_step!(T2::Data.Array{_T}, T::Data.Array{_T}, Ci::Data.Array{_T}, lam::_T, dt::_T, _dx::_T, _dy::_T, _dz::_T) where _T <: ParallelStencil.PSNumber
+    @inn(T2) = @inn(T) + dt*(lam*@inn(Ci)*(@d2_xi(T)*_dx^2 + @d2_yi(T)*_dy^2 + @d2_zi(T)*_dz^2));
+    return
+end
+
+function diffusion3D(lam::_T, c0::_T, lx::_T, ly::_T, lz::_T) where _T <: ParallelStencil.PSNumber
+
+# Numerics
+nx, ny, nz = 512, 512, 512;                              # Number of gridpoints in dimensions x, y and z
+nt         = 100;                                        # Number of time steps
+me, dims   = init_global_grid(nx, ny, nz);
+dx         = lx/(nx_g()-1);                              # Space step in x-dimension
+dy         = ly/(ny_g()-1);                              # Space step in y-dimension
+dz         = lz/(nz_g()-1);                              # Space step in z-dimension
+_dx, _dy, _dz = 1.0/dx, 1.0/dy, 1.0/dz;
+
+# Array initializations
+T   = @zeros(_T, nx, ny, nz);
+T2  = @zeros(_T, nx, ny, nz);
+Ci  = @zeros(_T, nx, ny, nz);
+
+# Initial conditions
+Ci .= 1/c0;                                              # 1/Heat capacity
+T  .= 1.7;
+T2 .= T;                                                 # Assign also T2 to get correct boundary conditions.
+
+# Time loop
+dt   = min(dx^2,dy^2,dz^2)/lam/maximum(Ci)/8.1;          # Time step for 3D Heat diffusion
+lam, dt, _dx, _dy, _dz = _T.((lam, dt, _dx, _dy, _dz))   # Convert all scalars to the required numbertype.
+for it = 1:nt
+    if (it == 11) tic(); end                             # Start measuring time.
+    @parallel diffusion3D_step!(T2, T, Ci, lam, dt, _dx, _dy, _dz);
+    update_halo!(T2);
+    T, T2 = T2, T;
+end
+time_s = toc()
+
+# Performance
+A_eff = (2*1+1)*1/1e9*nx*ny*nz*sizeof(_T);               # Effective main memory access per iteration [GB] (Lower bound of required memory access: T has to be read and written: 2 whole-array memaccess; Ci has to be read: : 1 whole-array memaccess)
+t_it  = time_s/(nt-10);                                  # Execution time per iteration [s]
+T_eff = A_eff/t_it;                                      # Effective memory throughput [GB/s]
+if (me==0) println("time_s=$time_s T_eff=$T_eff"); end
+
+finalize_global_grid();
+end
+
+
+################################################################################
+# CALL OF THE FUNCTION
+
+# Physics
+lam        = 1.0;                                        # Thermal conductivity
+c0         = 2.0;                                        # Heat capacity
+lx, ly, lz = 1.0, 1.0, 1.0;                              # Length of computational domain in dimension x, y and z
+
+lam, c0, lx, ly, lz = Float64.((lam, c0, lx, ly, lz))    # Convert all scalars to the desired numbertype.
+
+diffusion3D(lam, c0, lx, ly, lz)

--- a/src/ParallelKernel/Data.jl
+++ b/src/ParallelKernel/Data.jl
@@ -24,21 +24,37 @@ Expands to `Data.Array{numbertype, ndims}`, where `numbertype` is the datatype s
 """
 
 function Data_cuda(numbertype::DataType)
-    :(baremodule Data # NOTE: there cannot be any newline before 'module Data' or it will create a begin end block and the module creation will fail.
-        import CUDA
-        Number         = $numbertype
-        Array{N}       = CUDA.CuArray{$numbertype, N}
-        DeviceArray{N} = CUDA.CuDeviceArray{$numbertype, N}
-    end)
+    if numbertype == NUMBERTYPE_NONE
+        :(baremodule Data # NOTE: there cannot be any newline before 'module Data' or it will create a begin end block and the module creation will fail.
+            import CUDA
+            Array{T, N}       = CUDA.CuArray{T, N}
+            DeviceArray{T, N} = CUDA.CuDeviceArray{T, N}
+        end)
+    else
+        :(baremodule Data # NOTE: there cannot be any newline before 'module Data' or it will create a begin end block and the module creation will fail.
+            import CUDA
+            Number         = $numbertype
+            Array{N}       = CUDA.CuArray{$numbertype, N}
+            DeviceArray{N} = CUDA.CuDeviceArray{$numbertype, N}
+        end)
+    end
 end
 
 function Data_threads(numbertype::DataType)
-    :(baremodule Data # NOTE: there cannot be any newline before 'module Data' or it will create a begin end block and the module creation will fail.
-        import Base
-        Number         = $numbertype
-        Array{N}       = Base.Array{$numbertype, N}
-        DeviceArray{N} = Base.Array{$numbertype, N}
-    end)
+    if numbertype == NUMBERTYPE_NONE
+        :(baremodule Data # NOTE: there cannot be any newline before 'module Data' or it will create a begin end block and the module creation will fail.
+            import Base
+            Array{T, N}       = Base.Array{T, N}
+            DeviceArray{T, N} = Base.Array{T, N}
+        end)
+    else
+        :(baremodule Data # NOTE: there cannot be any newline before 'module Data' or it will create a begin end block and the module creation will fail.
+            import Base
+            Number         = $numbertype
+            Array{N}       = Base.Array{$numbertype, N}
+            DeviceArray{N} = Base.Array{$numbertype, N}
+        end)
+    end
 end
 
 function Data_none()

--- a/src/ParallelKernel/ParallelKernel.jl
+++ b/src/ParallelKernel/ParallelKernel.jl
@@ -55,5 +55,6 @@ include("reset_parallel_kernel.jl")
 ## Exports
 export @init_parallel_kernel, @parallel, @hide_communication, @parallel_indices, @parallel_async, @synchronize, @zeros, @ones, @rand
 export @gridDim, @blockIdx, @blockDim, @threadIdx, @sync_threads, @sharedMem, @pk_show, @pk_println
+export PKNumber
 
 end # Module ParallelKernel

--- a/src/ParallelKernel/allocators.jl
+++ b/src/ParallelKernel/allocators.jl
@@ -2,7 +2,13 @@
 const ZEROS_DOC = """
     @zeros(args...)
 
+!!! note "Advanced"
+        @zeros(numbertype, args...)
+
 Call `zeros(numbertype, args...)`, where `numbertype` is the datatype selected with [`@init_parallel_kernel`](@ref) and the function `zeros` is chosen to be compatible with the package for parallelization selected with [`@init_parallel_kernel`](@ref) (zeros for Threads and CUDA.zeros for CUDA).
+
+!!! note "Advanced"
+    The `numbertype` can be explicitly passed as argument in order to be used instead of the default `numbertype` chosen with [`@init_parallel_kernel`](@ref). If no default `numbertype` was chosen [`@init_parallel_kernel`](@ref), then the argument `numbertype` is mandatory. This needs to be used with care to ensure that no datatype conversions occurs in performance critical computations.
 """
 @doc ZEROS_DOC
 macro zeros(args...) check_initialized(); esc(_zeros(args...)); end
@@ -12,7 +18,13 @@ macro zeros(args...) check_initialized(); esc(_zeros(args...)); end
 const ONES_DOC = """
     @ones(args...)
 
+!!! note "Advanced"
+        @ones(numbertype, args...)
+
 Call `ones(numbertype, args...)`, where `numbertype` is the datatype selected with [`@init_parallel_kernel`](@ref) and the function `ones` is chosen to be compatible with the package for parallelization selected with [`@init_parallel_kernel`](@ref) (ones for Threads CUDA.ones for CUDA).
+
+!!! note "Advanced"
+    The `numbertype` can be explicitly passed as argument in order to be used instead of the default `numbertype` chosen with [`@init_parallel_kernel`](@ref). If no default `numbertype` was chosen [`@init_parallel_kernel`](@ref), then the argument `numbertype` is mandatory. This needs to be used with care to ensure that no datatype conversions occurs in performance critical computations.
 """
 @doc ONES_DOC
 macro ones(args...) check_initialized(); esc(_ones(args...)); end
@@ -22,7 +34,13 @@ macro ones(args...) check_initialized(); esc(_ones(args...)); end
 const RAND_DOC = """
     @rand(args...)
 
+!!! note "Advanced"
+        @rand(numbertype, args...)
+
 Call `rand(numbertype, args...)`, where `numbertype` is the datatype selected with [`@init_parallel_kernel`](@ref) and the function `rand` is chosen/implemented to be compatible with the package for parallelization selected with [`@init_parallel_kernel`](@ref).
+
+!!! note "Advanced"
+    The `numbertype` can be explicitly passed as argument in order to be used instead of the default `numbertype` chosen with [`@init_parallel_kernel`](@ref). If no default `numbertype` was chosen [`@init_parallel_kernel`](@ref), then the argument `numbertype` is mandatory. This needs to be used with care to ensure that no datatype conversions occurs in performance critical computations.
 """
 @doc RAND_DOC
 macro rand(args...) check_initialized(); esc(_rand(args...)); end
@@ -42,24 +60,52 @@ macro rand_threads(args...)  check_initialized(); esc(_rand(args...; package=PKG
 
 function _zeros(args...; package::Symbol=get_package())
     numbertype = get_numbertype()
-    if     (package == PKG_CUDA)    return :(CUDA.zeros($numbertype, $(args...)))
-    elseif (package == PKG_THREADS) return :(Base.zeros($numbertype, $(args...)))
-    else                            @KeywordArgumentError("$ERRMSG_UNSUPPORTED_PACKAGE (obtained: $package).")
-    end
+    if !(package in SUPPORTED_PACKAGES) @KeywordArgumentError("$ERRMSG_UNSUPPORTED_PACKAGE (obtained: $package).") end
+    return :(ParallelStencil.ParallelKernel.zeros_xpu($(args...); numbertype_default=$numbertype, package=Symbol($("$package"))))
 end
 
 function _ones(args...; package::Symbol=get_package())
     numbertype = get_numbertype()
-    if     (package == PKG_CUDA)    return :(CUDA.ones($numbertype, $(args...)))
-    elseif (package == PKG_THREADS) return :(Base.ones($numbertype, $(args...)))
-    else                            @KeywordArgumentError("$ERRMSG_UNSUPPORTED_PACKAGE (obtained: $package).")
-    end
+    if !(package in SUPPORTED_PACKAGES) @KeywordArgumentError("$ERRMSG_UNSUPPORTED_PACKAGE (obtained: $package).") end
+    return :(ParallelStencil.ParallelKernel.ones_xpu($(args...); numbertype_default=$numbertype, package=Symbol($("$package"))))
 end
 
 function _rand(args...; package::Symbol=get_package())
     numbertype = get_numbertype()
-    if     (package == PKG_CUDA)    return :(CUDA.CuArray(rand($numbertype, $(args...))))
-    elseif (package == PKG_THREADS) return :(Base.rand($numbertype, $(args...)))
-    else                            @KeywordArgumentError("$ERRMSG_UNSUPPORTED_PACKAGE (obtained: $package).")
+    if !(package in SUPPORTED_PACKAGES) @KeywordArgumentError("$ERRMSG_UNSUPPORTED_PACKAGE (obtained: $package).") end
+    return :(ParallelStencil.ParallelKernel.rand_xpu($(args...); numbertype_default=$numbertype, package=Symbol($("$package"))))
+end
+
+function zeros_xpu(args...; numbertype_default::DataType=NUMBERTYPE_NONE, package::Symbol=PKG_NONE)
+    numbertype, args_remainder = determine_args(args...; numbertype_default=numbertype_default, package=package)
+    if     (package == PKG_CUDA)    return CUDA.zeros(numbertype, args_remainder...)
+    elseif (package == PKG_THREADS) return Base.zeros(numbertype, args_remainder...)
     end
+end
+
+function ones_xpu(args...; numbertype_default::DataType=NUMBERTYPE_NONE, package::Symbol=PKG_NONE)
+    numbertype, args_remainder = determine_args(args...; numbertype_default=numbertype_default, package=package)
+    if     (package == PKG_CUDA)    return CUDA.ones(numbertype, args_remainder...)
+    elseif (package == PKG_THREADS) return Base.ones(numbertype, args_remainder...)
+    end
+end
+
+function rand_xpu(args...; numbertype_default::DataType=NUMBERTYPE_NONE, package::Symbol=PKG_NONE)
+    numbertype, args_remainder = determine_args(args...; numbertype_default=numbertype_default, package=package)
+    if     (package == PKG_CUDA)    return CUDA.CuArray(rand(numbertype, args_remainder...))
+    elseif (package == PKG_THREADS) return Base.rand(numbertype, args_remainder...)
+    end
+end
+
+function determine_args(args...; numbertype_default::DataType=NUMBERTYPE_NONE, package::Symbol=PKG_NONE)
+    if length(args) > 0 && isa(args[1], DataType)
+        numbertype     = args[1]
+        args_remainder = args[2:end]
+    elseif numbertype_default != NUMBERTYPE_NONE
+        numbertype = numbertype_default
+        args_remainder = args
+    else
+        @ArgumentError("the numbertype argument is mandatory when no default is set.")
+    end
+    return numbertype, args_remainder
 end

--- a/src/ParallelKernel/allocators.jl
+++ b/src/ParallelKernel/allocators.jl
@@ -8,7 +8,7 @@ const ZEROS_DOC = """
 Call `zeros(numbertype, args...)`, where `numbertype` is the datatype selected with [`@init_parallel_kernel`](@ref) and the function `zeros` is chosen to be compatible with the package for parallelization selected with [`@init_parallel_kernel`](@ref) (zeros for Threads and CUDA.zeros for CUDA).
 
 !!! note "Advanced"
-    The `numbertype` can be explicitly passed as argument in order to be used instead of the default `numbertype` chosen with [`@init_parallel_kernel`](@ref). If no default `numbertype` was chosen [`@init_parallel_kernel`](@ref), then the argument `numbertype` is mandatory. This needs to be used with care to ensure that no datatype conversions occurs in performance critical computations.
+    The `numbertype` can be explicitly passed as argument in order to be used instead of the default `numbertype` chosen with [`@init_parallel_kernel`](@ref). If no default `numbertype` was chosen [`@init_parallel_kernel`](@ref), then the argument `numbertype` is mandatory. This needs to be used with care to ensure that no datatype conversions occur in performance critical computations.
 """
 @doc ZEROS_DOC
 macro zeros(args...) check_initialized(); esc(_zeros(args...)); end
@@ -24,7 +24,7 @@ const ONES_DOC = """
 Call `ones(numbertype, args...)`, where `numbertype` is the datatype selected with [`@init_parallel_kernel`](@ref) and the function `ones` is chosen to be compatible with the package for parallelization selected with [`@init_parallel_kernel`](@ref) (ones for Threads CUDA.ones for CUDA).
 
 !!! note "Advanced"
-    The `numbertype` can be explicitly passed as argument in order to be used instead of the default `numbertype` chosen with [`@init_parallel_kernel`](@ref). If no default `numbertype` was chosen [`@init_parallel_kernel`](@ref), then the argument `numbertype` is mandatory. This needs to be used with care to ensure that no datatype conversions occurs in performance critical computations.
+    The `numbertype` can be explicitly passed as argument in order to be used instead of the default `numbertype` chosen with [`@init_parallel_kernel`](@ref). If no default `numbertype` was chosen [`@init_parallel_kernel`](@ref), then the argument `numbertype` is mandatory. This needs to be used with care to ensure that no datatype conversions occur in performance critical computations.
 """
 @doc ONES_DOC
 macro ones(args...) check_initialized(); esc(_ones(args...)); end
@@ -40,7 +40,7 @@ const RAND_DOC = """
 Call `rand(numbertype, args...)`, where `numbertype` is the datatype selected with [`@init_parallel_kernel`](@ref) and the function `rand` is chosen/implemented to be compatible with the package for parallelization selected with [`@init_parallel_kernel`](@ref).
 
 !!! note "Advanced"
-    The `numbertype` can be explicitly passed as argument in order to be used instead of the default `numbertype` chosen with [`@init_parallel_kernel`](@ref). If no default `numbertype` was chosen [`@init_parallel_kernel`](@ref), then the argument `numbertype` is mandatory. This needs to be used with care to ensure that no datatype conversions occurs in performance critical computations.
+    The `numbertype` can be explicitly passed as argument in order to be used instead of the default `numbertype` chosen with [`@init_parallel_kernel`](@ref). If no default `numbertype` was chosen [`@init_parallel_kernel`](@ref), then the argument `numbertype` is mandatory. This needs to be used with care to ensure that no datatype conversions occur in performance critical computations.
 """
 @doc RAND_DOC
 macro rand(args...) check_initialized(); esc(_rand(args...)); end

--- a/src/ParallelKernel/parallel.jl
+++ b/src/ParallelKernel/parallel.jl
@@ -96,7 +96,7 @@ function checkargs_parallel_indices(args...)
     if (length(args) != 2) @ArgumentError("wrong number of arguments.") end
     if !is_kernel(args[end]) @ArgumentError("the last argument must be a kernel definition (obtained: $(args[end])).") end
     kernel = args[end]
-    if length(extract_kernel_args(kernel)[2]) > 0 @ArgumentError("keyword arguments are not allowed int the signature of @parallel_indices kernels.") end
+    if length(extract_kernel_args(kernel)[2]) > 0 @ArgumentError("keyword arguments are not allowed in the signature of @parallel_indices kernels.") end
 end
 
 

--- a/src/ParallelKernel/parallel.jl
+++ b/src/ParallelKernel/parallel.jl
@@ -89,7 +89,7 @@ function checkargs_parallel(args...)
     posargs, = split_parallel_args(args)
     if length(posargs) > 3 @ArgumentError("too many positional arguments.") end
     kernelcall = args[end]
-    if length(extract_kernelcall_args(kernelcall)[2]) > 0 @ArgumentError("keyword arguments are not allowed int @parallel kernel calls.") end
+    if length(extract_kernelcall_args(kernelcall)[2]) > 0 @ArgumentError("keyword arguments are not allowed in @parallel kernel calls.") end
 end
 
 function checkargs_parallel_indices(args...)

--- a/src/ParallelStencil.jl
+++ b/src/ParallelStencil.jl
@@ -62,5 +62,6 @@ include("FiniteDifferences.jl")
 export @init_parallel_stencil, FiniteDifferences1D, FiniteDifferences2D, FiniteDifferences3D
 export @parallel, @hide_communication, @parallel_indices, @parallel_async, @synchronize, @zeros, @ones, @rand
 export @gridDim, @blockIdx, @blockDim, @threadIdx, @sync_threads, @sharedMem, @ps_show, @ps_println
+export PSNumber
 
 end # Module ParallelStencil

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -24,12 +24,14 @@ macro parallel_threads(args...) check_initialized(); checkargs_parallel(args...)
 
 function checkargs_parallel(args...)
     if isempty(args) @ArgumentError("arguments missing.") end
-    if is_function(args[end])  # Case: @parallel kernel
+    if is_kernel(args[end])  # Case: @parallel kernel
         if (length(args) != 1) @ArgumentError("wrong number of arguments in @parallel kernel call.") end
+        kernel = args[end]
+        if length(extract_kernel_args(kernel)[2]) > 0 @ArgumentError("keyword arguments are not allowed int the signature of @parallel kernels.") end
     elseif is_call(args[end])  # Case: @parallel <args...> kernelcall
         ParallelKernel.checkargs_parallel(args...)
     else
-        @ArgumentError("the last argument must be a function definition or a kernel call (obtained: $(args[end])).")
+        @ArgumentError("the last argument must be a kernel definition or a kernel call (obtained: $(args[end])).")
     end
 end
 
@@ -37,7 +39,7 @@ end
 ## GATEWAY FUNCTIONS
 
 function parallel(caller::Module, args::Union{Symbol,Expr}...; package::Symbol=get_package())
-    if is_function(args[end])
+    if is_kernel(args[end])
         numbertype = get_numbertype()
         ndims      = get_ndims()
         parallel_kernel(caller, package, numbertype, ndims, args...)

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -27,7 +27,7 @@ function checkargs_parallel(args...)
     if is_kernel(args[end])  # Case: @parallel kernel
         if (length(args) != 1) @ArgumentError("wrong number of arguments in @parallel kernel call.") end
         kernel = args[end]
-        if length(extract_kernel_args(kernel)[2]) > 0 @ArgumentError("keyword arguments are not allowed int the signature of @parallel kernels.") end
+        if length(extract_kernel_args(kernel)[2]) > 0 @ArgumentError("keyword arguments are not allowed in the signature of @parallel kernels.") end
     elseif is_call(args[end])  # Case: @parallel <args...> kernelcall
         ParallelKernel.checkargs_parallel(args...)
     else

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -3,8 +3,8 @@ import .ParallelKernel: ENABLE_CUDA  # ENABLE_CUDA must also always be accessibl
 @static if ENABLE_CUDA
     using CUDA
 end
-import .ParallelKernel: checkargs_init, check_numbertype, eval_arg, is_function, is_call, gensym_world
-import .ParallelKernel: PKG_CUDA, PKG_THREADS, PKG_NONE, NUMBERTYPE_NONE, SUPPORTED_NUMBERTYPES, SUPPORTED_PACKAGES, ERRMSG_UNSUPPORTED_PACKAGE, INT_CUDA, INT_THREADS, INDICES
+import .ParallelKernel: eval_arg, split_args, split_kwargs, extract_posargs_init, extract_kernel_args, is_kernel, is_call, gensym_world
+import .ParallelKernel: PKG_CUDA, PKG_THREADS, PKG_NONE, NUMBERTYPE_NONE, SUPPORTED_NUMBERTYPES, SUPPORTED_PACKAGES, ERRMSG_UNSUPPORTED_PACKAGE, INT_CUDA, INT_THREADS, INDICES, PKNumber
 import .ParallelKernel: @require, @symbols, symbols, longnameof, @prettyexpand, @prettystring, prettystring, @gorgeousexpand, @gorgeousstring, gorgeousstring
 
 
@@ -23,9 +23,10 @@ const SUPPORTED_NDIMS = [1, 2, 3]
 const NDIMS_NONE = 0
 const ERRMSG_KERNEL_UNSUPPORTED = "unsupported kernel statements in @parallel kernel definition: @parallel is only applicable to kernels that contain exclusively array assignments using macros from FiniteDifferences{1|2|3}D or from another compatible computation submodule. @parallel_indices supports any kind of statements in the kernels."
 const ERRMSG_CHECK_NDIMS  = "ndims must be noted LITERALLY (NOT a variable containing the ndims) and has to be one of the following: $(join(SUPPORTED_NDIMS,", "))"
+const PSNumber = PKNumber
 
 
-## FUNCTIONS TO DEAL WITH FUNCTION DEFINITIONS
+## FUNCTIONS TO DEAL WITH KERNEL DEFINITIONS
 
 function validate_body(body::Expr)
     statements = (body.head == :block) ? body.args : [body]

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -4,7 +4,7 @@ import .ParallelKernel: ENABLE_CUDA  # ENABLE_CUDA must also always be accessibl
     using CUDA
 end
 import .ParallelKernel: eval_arg, split_args, split_kwargs, extract_posargs_init, extract_kernel_args, is_kernel, is_call, gensym_world
-import .ParallelKernel: PKG_CUDA, PKG_THREADS, PKG_NONE, NUMBERTYPE_NONE, SUPPORTED_NUMBERTYPES, SUPPORTED_PACKAGES, ERRMSG_UNSUPPORTED_PACKAGE, INT_CUDA, INT_THREADS, INDICES
+import .ParallelKernel: PKG_CUDA, PKG_THREADS, PKG_NONE, NUMBERTYPE_NONE, SUPPORTED_NUMBERTYPES, SUPPORTED_PACKAGES, ERRMSG_UNSUPPORTED_PACKAGE, INT_CUDA, INT_THREADS, INDICES, PKNumber
 import .ParallelKernel: @require, @symbols, symbols, longnameof, @prettyexpand, @prettystring, prettystring, @gorgeousexpand, @gorgeousstring, gorgeousstring
 
 

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -4,7 +4,7 @@ import .ParallelKernel: ENABLE_CUDA  # ENABLE_CUDA must also always be accessibl
     using CUDA
 end
 import .ParallelKernel: eval_arg, split_args, split_kwargs, extract_posargs_init, extract_kernel_args, is_kernel, is_call, gensym_world
-import .ParallelKernel: PKG_CUDA, PKG_THREADS, PKG_NONE, NUMBERTYPE_NONE, SUPPORTED_NUMBERTYPES, SUPPORTED_PACKAGES, ERRMSG_UNSUPPORTED_PACKAGE, INT_CUDA, INT_THREADS, INDICES, PKNumber
+import .ParallelKernel: PKG_CUDA, PKG_THREADS, PKG_NONE, NUMBERTYPE_NONE, SUPPORTED_NUMBERTYPES, SUPPORTED_PACKAGES, ERRMSG_UNSUPPORTED_PACKAGE, INT_CUDA, INT_THREADS, INDICES
 import .ParallelKernel: @require, @symbols, symbols, longnameof, @prettyexpand, @prettystring, prettystring, @gorgeousexpand, @gorgeousstring, gorgeousstring
 
 

--- a/test/ParallelKernel/test_allocators.jl
+++ b/test/ParallelKernel/test_allocators.jl
@@ -1,7 +1,7 @@
 using Test
 import ParallelStencil
 using ParallelStencil.ParallelKernel
-import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, SUPPORTED_PACKAGES, PKG_CUDA
+import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, @get_numbertype, NUMBERTYPE_NONE, SUPPORTED_PACKAGES, PKG_CUDA
 import ParallelStencil.ParallelKernel: @require
 TEST_PACKAGES = SUPPORTED_PACKAGES
 @static if PKG_CUDA in TEST_PACKAGES
@@ -11,18 +11,50 @@ end
 
 @static for package in TEST_PACKAGES  eval(:(
     @testset "$(basename(@__FILE__)) (package: $(nameof($package)))" begin
-        @testset "1. allocator macros" begin
+        @testset "1. allocator macros (with default numbertype)" begin
             @require !@is_initialized()
             @init_parallel_kernel($package, Float16)
             @require @is_initialized()
             @testset "mapping to package" begin
-                @test @zeros(2,3) == parentmodule($package).zeros(Float16,2,3)
-                @test @ones(2,3) == parentmodule($package).ones(Float16,2,3)
+                @test @zeros(2,3)         == parentmodule($package).zeros(Float16,2,3)
+                @test @zeros(Float32,2,3) == parentmodule($package).zeros(Float32,2,3)
+                @test @ones(2,3)          == parentmodule($package).ones(Float16,2,3)
+                @test @ones(Float32,2,3)  == parentmodule($package).ones(Float32,2,3)
                 @static if $package == $PKG_CUDA
-                    @test typeof(@rand(2,3)) == typeof(CUDA.CuArray(rand(Float16,2,3)))
+                    @test typeof(@rand(2,3))         == typeof(CUDA.CuArray(rand(Float16,2,3)))
+                    @test typeof(@rand(Float64,2,3)) == typeof(CUDA.CuArray(rand(Float64,2,3)))
                 else
-                    @test typeof(@rand(2,3)) == typeof(parentmodule($package).rand(Float16,2,3))
+                    @test typeof(@rand(2,3))         == typeof(parentmodule($package).rand(Float16,2,3))
+                    @test typeof(@rand(Float64,2,3)) == typeof(parentmodule($package).rand(Float64,2,3))
                 end
+            end;
+            @reset_parallel_kernel()
+        end;
+        @testset "2. allocator macros (no default numbertype)" begin
+            @require !@is_initialized()
+            @init_parallel_kernel(package = $package)
+            @require @is_initialized()
+            @require @get_numbertype() == NUMBERTYPE_NONE
+            @testset "mapping to package" begin
+                @test @zeros(Float32,2,3) == parentmodule($package).zeros(Float32,2,3)
+                @test @ones(Float32,2,3)  == parentmodule($package).ones(Float32,2,3)
+                @static if $package == $PKG_CUDA
+                    @test typeof(@rand(Float64,2,3)) == typeof(CUDA.CuArray(rand(Float64,2,3)))
+                else
+                    @test typeof(@rand(Float64,2,3)) == typeof(parentmodule($package).rand(Float64,2,3))
+                end
+            end;
+            @reset_parallel_kernel()
+        end;
+        @testset "3. Exceptions (no default numbertype)" begin
+            @require !@is_initialized()
+            @init_parallel_kernel(package = $package)
+            @require @is_initialized()
+            @require @get_numbertype() == $NUMBERTYPE_NONE
+            @testset "no numbertype" begin
+                @test_throws ArgumentError @zeros(2,3)
+                @test_throws ArgumentError @ones(2,3)
+                @test_throws ArgumentError @rand(2,3)
             end;
             @reset_parallel_kernel()
         end;

--- a/test/ParallelKernel/test_init_parallel_kernel.jl
+++ b/test/ParallelKernel/test_init_parallel_kernel.jl
@@ -1,9 +1,9 @@
 using Test
 import ParallelStencil
 using ParallelStencil.ParallelKernel
-import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, @get_package, @get_numbertype, SUPPORTED_PACKAGES, PKG_CUDA
+import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, @get_package, @get_numbertype, NUMBERTYPE_NONE, SUPPORTED_PACKAGES, PKG_CUDA
 import ParallelStencil.ParallelKernel: @require, @symbols
-import ParallelStencil.ParallelKernel: checkargs_init, check_already_initialized, set_initialized, is_initialized, check_initialized
+import ParallelStencil.ParallelKernel: extract_posargs_init, extract_kwargs_init, check_already_initialized, set_initialized, is_initialized, check_initialized
 using ParallelStencil.ParallelKernel.Exceptions
 TEST_PACKAGES = SUPPORTED_PACKAGES
 @static if PKG_CUDA in TEST_PACKAGES
@@ -30,7 +30,24 @@ end
             end;
             @reset_parallel_kernel()
         end;
-        @testset "2. Exceptions" begin
+        @testset "2. initialization of ParallelKernel without numbertype" begin
+            @require !@is_initialized()
+            @init_parallel_kernel(package = $package)
+            @testset "initialized" begin
+                @test @is_initialized()
+                @test @get_package() == $package
+                @test @get_numbertype() == NUMBERTYPE_NONE
+            end;
+            @testset "Data" begin
+                @test @isdefined(Data)
+                @test length(@symbols($(@__MODULE__), Data)) > 1
+                @test !(Symbol("Number") in @symbols($(@__MODULE__), Data))
+                @test Symbol("Array") in @symbols($(@__MODULE__), Data)
+                @test Symbol("DeviceArray") in @symbols($(@__MODULE__), Data)
+            end;
+            @reset_parallel_kernel()
+        end;
+        @testset "3. Exceptions" begin
             @testset "already initialized" begin
                 set_initialized(true)
                 @require is_initialized()
@@ -38,9 +55,14 @@ end
                 set_initialized(false)
             end;
             @testset "arguments" begin
-                MyType = Float32
-                @test_throws ArgumentError checkargs_init(5, Float64)
-                @test_throws ArgumentError checkargs_init($package, MyType)
+                @test_throws ArgumentError extract_posargs_init($(@__MODULE__), 99, :Float64)
+                @test_throws ArgumentError extract_posargs_init($(@__MODULE__), nameof($package), :Char)
+                @test_throws ArgumentEvaluationError extract_posargs_init($(@__MODULE__), nameof($package), :MyType)
+                @test_throws ArgumentError extract_kwargs_init($(@__MODULE__), Dict(:package => 99, :numbertype => :Float64))
+                @test_throws ArgumentError extract_kwargs_init($(@__MODULE__), Dict(:package => nameof($package), :numbertype => :Char))
+                @test_throws ArgumentEvaluationError extract_kwargs_init($(@__MODULE__), Dict(:package => nameof($package), :numbertype => :MyType))
+                @test_throws ArgumentError extract_kwargs_init($(@__MODULE__), Dict(:numbertype => :Char))
+                @test_throws ArgumentEvaluationError extract_kwargs_init($(@__MODULE__), Dict(:numbertype => :MyType))
             end;
             @testset "check_initialized" begin
                 @require !is_initialized()

--- a/test/ParallelKernel/test_parallel.jl
+++ b/test/ParallelKernel/test_parallel.jl
@@ -38,50 +38,62 @@ end
                     @test @prettystring(1, @parallel stream=mystream f(A)) == "f(A, ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))[1])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))[2])), (Int64)(length((ParallelStencil.ParallelKernel.promote_ranges(ParallelStencil.ParallelKernel.get_ranges(A)))[3])))"
                 end;
             end;
-            @testset "@parallel_indices (1D)" begin
-                A  = @zeros(4)
-                @parallel_indices (ix) function write_indices!(A)
-                    A[ix] = ix;
-                    return
+            @testset "@parallel_indices" begin
+                @testset "addition of range arguments" begin
+                    expansion = @prettystring(1, @parallel_indices (ix,iy) f(a::T, b::T) where T <: Union{Array{Float32}, Array{Float64}} = (println("a=$a, b=$b)"); return))
+                    @test occursin("f(a::T, b::T, var\"##ranges, ParallelStencil.ParallelKernel#260\"::Tuple{UnitRange, UnitRange, UnitRange}, var\"##rangelength_x, ParallelStencil.ParallelKernel#261\"::Int64, var\"##rangelength_y, ParallelStencil.ParallelKernel#262\"::Int64, var\"##rangelength_z, ParallelStencil.ParallelKernel#263\"::Int64", expansion)
                 end
-                @parallel write_indices!(A);
-                @test all(Array(A) .== [ix for ix=1:size(A,1)])
-            end;
-            @testset "@parallel_indices (2D)" begin
-                A  = @zeros(4, 5)
-                @parallel_indices (ix,iy) function write_indices!(A)
-                    A[ix,iy] = ix + (iy-1)*size(A,1);
-                    return
+                @testset "Data.Array to Data.DeviceArray" begin
+                    @static if $package == $PKG_CUDA
+                            expansion = @prettystring(1, @parallel_indices (ix,iy) f(A::Data.Array, B::Data.Array, c::T) where T <: Integer = (A[ix,iy] = B[ix,iy]^c; return))
+                            @test occursin("f(A::Data.DeviceArray, B::Data.DeviceArray,", expansion)
+                    end
                 end
-                @parallel write_indices!(A);
-                @test all(Array(A) .== [ix + (iy-1)*size(A,1) for ix=1:size(A,1), iy=1:size(A,2)])
-            end;
-            @testset "@parallel_indices (3D)" begin
-                A  = @zeros(4, 5, 6)
-                @parallel_indices (ix,iy,iz) function write_indices!(A)
-                    A[ix,iy,iz] = ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2);
-                    return
-                end
-                @parallel write_indices!(A);
-                @test all(Array(A) .== [ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2) for ix=1:size(A,1), iy=1:size(A,2), iz=1:size(A,3)])
-            end;
-            @testset "@parallel_indices (1D in 3D)" begin
-                A  = @zeros(4, 5, 6)
-                @parallel_indices (iy) function write_indices!(A)
-                    A[1,iy,1] = iy;
-                    return
-                end
-                @parallel 1:size(A,2) write_indices!(A);
-                @test all(Array(A)[1,:,1] .== [iy for iy=1:size(A,2)])
-            end;
-            @testset "@parallel_indices (2D in 3D)" begin
-                A  = @zeros(4, 5, 6)
-                @parallel_indices (ix,iz) function write_indices!(A)
-                    A[ix,end,iz] = ix + (iz-1)*size(A,1);
-                    return
-                end
-                @parallel (1:size(A,1), 1:size(A,3)) write_indices!(A);
-                @test all(Array(A)[:,end,:] .== [ix + (iz-1)*size(A,1) for ix=1:size(A,1), iz=1:size(A,3)])
+                @testset "@parallel_indices (1D)" begin
+                    A  = @zeros(4)
+                    @parallel_indices (ix) function write_indices!(A)
+                        A[ix] = ix;
+                        return
+                    end
+                    @parallel write_indices!(A);
+                    @test all(Array(A) .== [ix for ix=1:size(A,1)])
+                end;
+                @testset "@parallel_indices (2D)" begin
+                    A  = @zeros(4, 5)
+                    @parallel_indices (ix,iy) function write_indices!(A)
+                        A[ix,iy] = ix + (iy-1)*size(A,1);
+                        return
+                    end
+                    @parallel write_indices!(A);
+                    @test all(Array(A) .== [ix + (iy-1)*size(A,1) for ix=1:size(A,1), iy=1:size(A,2)])
+                end;
+                @testset "@parallel_indices (3D)" begin
+                    A  = @zeros(4, 5, 6)
+                    @parallel_indices (ix,iy,iz) function write_indices!(A)
+                        A[ix,iy,iz] = ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2);
+                        return
+                    end
+                    @parallel write_indices!(A);
+                    @test all(Array(A) .== [ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2) for ix=1:size(A,1), iy=1:size(A,2), iz=1:size(A,3)])
+                end;
+                @testset "@parallel_indices (1D in 3D)" begin
+                    A  = @zeros(4, 5, 6)
+                    @parallel_indices (iy) function write_indices!(A)
+                        A[1,iy,1] = iy;
+                        return
+                    end
+                    @parallel 1:size(A,2) write_indices!(A);
+                    @test all(Array(A)[1,:,1] .== [iy for iy=1:size(A,2)])
+                end;
+                @testset "@parallel_indices (2D in 3D)" begin
+                    A  = @zeros(4, 5, 6)
+                    @parallel_indices (ix,iz) function write_indices!(A)
+                        A[ix,end,iz] = ix + (iz-1)*size(A,1);
+                        return
+                    end
+                    @parallel (1:size(A,1), 1:size(A,3)) write_indices!(A);
+                    @test all(Array(A)[:,end,:] .== [ix + (iz-1)*size(A,1) for ix=1:size(A,1), iz=1:size(A,3)])
+                end;
             end;
             @testset "@parallel_async" begin
                 @static if $package == $PKG_CUDA
@@ -146,7 +158,19 @@ end
                 @reset_parallel_kernel()
             end;
         end
-        @testset "3. Exceptions" begin
+        @testset "3. parallel macros (numbertype ommited)" begin
+            @require !@is_initialized()
+            @init_parallel_kernel(package = $package)
+            @require @is_initialized
+            @testset "Data.Array{T} to Data.DeviceArray{T}" begin
+                @static if $package == $PKG_CUDA
+                        expansion = @prettystring(1, @parallel_indices (ix,iy) f(A::Data.Array{T}, B::Data.Array{T}, c) where T <: Union{Float32, Float64}  = (A[ix,iy] = B[ix,iy]^c; return))
+                        @test occursin("f(A::Data.DeviceArray{T}, B::Data.DeviceArray{T},", expansion)
+                end
+            end
+            @reset_parallel_kernel()
+        end
+        @testset "4. Exceptions" begin
             @require !@is_initialized()
             @init_parallel_kernel($package, Float64)
             @require @is_initialized
@@ -154,6 +178,8 @@ end
                 @test_throws ArgumentError checkargs_parallel();                                                    # Error: isempty(args)
                 @test_throws ArgumentError checkargs_parallel(:(f()), :(something));                                # Error: last arg is not function call.
                 @test_throws ArgumentError checkargs_parallel(:(f()=99));                                           # Error: last arg is not function call.
+                #TODO: Here I am: kw for calls look very different: head :kw - fix in parallel.jl/shared.jl
+                @test_throws ArgumentError checkargs_parallel(:(f(;s=1)));                                          # Error: function call with keyword argument.
                 @test_throws ArgumentError checkargs_parallel(:ranges, :nblocks, :nthreads, :something, :(f()));    # Error: length(posargs) > 3
                 @test_throws KeywordArgumentError checkargs_parallel(:(blocks=blocks), :(f()));                     # Error: blocks keyword argument is not allowed
                 @test_throws KeywordArgumentError checkargs_parallel(:(threads=threads), :(f()));                   # Error: threads keyword argument is not allowed
@@ -165,6 +191,7 @@ end
                 @test_throws ArgumentError checkargs_parallel_indices(:ix, :iy, :iz, :(f()=99));                    # Error: length(args) != 2
                 @test_throws ArgumentError checkargs_parallel_indices(:(f()=99), :((ix,iy,iz)));                    # Error: last arg is not function.
                 @test_throws ArgumentError checkargs_parallel_indices(:((ix,iy,iz)), :(f()));                       # Error: last arg is not function.
+                @test_throws ArgumentError checkargs_parallel_indices(:((ix,iy,iz)), :(f(;s=1)=(99*s; return)))     # Error: function defines keyword.
                 @test_throws ArgumentError parallel_indices(:((ix,iy,iz)), :(f()=99))                               # Error: no return statement in function.
                 @test_throws ArgumentError parallel_indices(:((ix,iy,iz)), :(f()=(99; return something)))           # Error: function does not return nothing.
                 #TODO: this tests does not pass anymore for unknown reasons:

--- a/test/ParallelKernel/test_parallel.jl
+++ b/test/ParallelKernel/test_parallel.jl
@@ -2,7 +2,7 @@ using Test
 import ParallelStencil
 using ParallelStencil.ParallelKernel
 import ParallelStencil.ParallelKernel: @reset_parallel_kernel, @is_initialized, SUPPORTED_PACKAGES, PKG_CUDA, PKG_THREADS
-import ParallelStencil.ParallelKernel: @require, @prettystring
+import ParallelStencil.ParallelKernel: @require, @prettystring, @gorgeousstring
 import ParallelStencil.ParallelKernel: checkargs_parallel, checkargs_parallel_indices, parallel_indices
 using ParallelStencil.ParallelKernel.Exceptions
 TEST_PACKAGES = SUPPORTED_PACKAGES
@@ -40,8 +40,8 @@ end
             end;
             @testset "@parallel_indices" begin
                 @testset "addition of range arguments" begin
-                    expansion = @prettystring(1, @parallel_indices (ix,iy) f(a::T, b::T) where T <: Union{Array{Float32}, Array{Float64}} = (println("a=$a, b=$b)"); return))
-                    @test occursin("f(a::T, b::T, var\"##ranges, ParallelStencil.ParallelKernel#260\"::Tuple{UnitRange, UnitRange, UnitRange}, var\"##rangelength_x, ParallelStencil.ParallelKernel#261\"::Int64, var\"##rangelength_y, ParallelStencil.ParallelKernel#262\"::Int64, var\"##rangelength_z, ParallelStencil.ParallelKernel#263\"::Int64", expansion)
+                    expansion = @gorgeousstring(1, @parallel_indices (ix,iy) f(a::T, b::T) where T <: Union{Array{Float32}, Array{Float64}} = (println("a=$a, b=$b)"); return))
+                    @test occursin("f(a::T, b::T, ranges::Tuple{UnitRange, UnitRange, UnitRange}, rangelength_x::Int64, rangelength_y::Int64, rangelength_z::Int64", expansion)
                 end
                 @testset "Data.Array to Data.DeviceArray" begin
                     @static if $package == $PKG_CUDA

--- a/test/ParallelKernel/test_parallel.jl
+++ b/test/ParallelKernel/test_parallel.jl
@@ -164,7 +164,7 @@ end
             @require @is_initialized
             @testset "Data.Array{T} to Data.DeviceArray{T}" begin
                 @static if $package == $PKG_CUDA
-                        expansion = @prettystring(1, @parallel_indices (ix,iy) f(A::Data.Array{T}, B::Data.Array{T}, c::<:Integer) where T <: Union{Float32, Float64}  = (A[ix,iy] = B[ix,iy]^c; return))
+                        expansion = @prettystring(1, @parallel_indices (ix,iy) f(A::Data.Array{T}, B::Data.Array{T}, c<:Integer) where T <: Union{Float32, Float64}  = (A[ix,iy] = B[ix,iy]^c; return))
                         @test occursin("f(A::Data.DeviceArray{T}, B::Data.DeviceArray{T},", expansion)
                 end
             end

--- a/test/ParallelKernel/test_parallel.jl
+++ b/test/ParallelKernel/test_parallel.jl
@@ -164,7 +164,7 @@ end
             @require @is_initialized
             @testset "Data.Array{T} to Data.DeviceArray{T}" begin
                 @static if $package == $PKG_CUDA
-                        expansion = @prettystring(1, @parallel_indices (ix,iy) f(A::Data.Array{T}, B::Data.Array{T}, c) where T <: Union{Float32, Float64}  = (A[ix,iy] = B[ix,iy]^c; return))
+                        expansion = @prettystring(1, @parallel_indices (ix,iy) f(A::Data.Array{T}, B::Data.Array{T}, c::<:Integer) where T <: Union{Float32, Float64}  = (A[ix,iy] = B[ix,iy]^c; return))
                         @test occursin("f(A::Data.DeviceArray{T}, B::Data.DeviceArray{T},", expansion)
                 end
             end

--- a/test/test_parallel.jl
+++ b/test/test_parallel.jl
@@ -73,7 +73,7 @@ end
             @require @is_initialized
             @testset "Data.Array{T} to Data.DeviceArray{T}" begin
                 @static if $package == $PKG_CUDA
-                    expansion = @prettystring(1, @parallel f(A::Data.Array{T}, B::Data.Array{T}, c::<:Integer) where T <: PSNumber = (@all(A) = @all(B)^c; return))
+                    expansion = @prettystring(1, @parallel f(A::Data.Array{T}, B::Data.Array{T}, c<:Integer) where T <: PSNumber = (@all(A) = @all(B)^c; return))
                     @test occursin("f(A::Data.DeviceArray{T}, B::Data.DeviceArray{T},", expansion)
                 end
             end

--- a/test/test_parallel.jl
+++ b/test/test_parallel.jl
@@ -1,7 +1,7 @@
 using Test
 using ParallelStencil
 import ParallelStencil: @reset_parallel_stencil, @is_initialized, SUPPORTED_PACKAGES, PKG_CUDA, PKG_THREADS, INDICES
-import ParallelStencil: @require, @prettystring
+import ParallelStencil: @require, @prettystring, @gorgeousstring
 import ParallelStencil: checkargs_parallel, validate_body, parallel
 using ParallelStencil.Exceptions
 using ParallelStencil.FiniteDifferences3D
@@ -41,8 +41,8 @@ end
             end;
             @testset "@parallel kernel" begin
                 @testset "addition of range arguments" begin
-                    expansion = @prettystring(1, @parallel f(A, B, c::T) where T <: Integer = (@all(A) = @all(B)^c; return))
-                    @test occursin("f(A, B, c::T, var\"##ranges, ParallelStencil.ParallelKernel#260\"::Tuple{UnitRange, UnitRange, UnitRange}, var\"##rangelength_x, ParallelStencil.ParallelKernel#261\"::Int64, var\"##rangelength_y, ParallelStencil.ParallelKernel#262\"::Int64, var\"##rangelength_z, ParallelStencil.ParallelKernel#263\"::Int64", expansion)
+                    expansion = @gorgeousstring(1, @parallel f(A, B, c::T) where T <: Integer = (@all(A) = @all(B)^c; return))
+                    @test occursin("f(A, B, c::T, ranges::Tuple{UnitRange, UnitRange, UnitRange}, rangelength_x::Int64, rangelength_y::Int64, rangelength_z::Int64", expansion)
                 end
                 @testset "Data.Array to Data.DeviceArray" begin
                     @static if $package == $PKG_CUDA

--- a/test/test_parallel.jl
+++ b/test/test_parallel.jl
@@ -73,7 +73,7 @@ end
             @require @is_initialized
             @testset "Data.Array{T} to Data.DeviceArray{T}" begin
                 @static if $package == $PKG_CUDA
-                    expansion = @prettystring(1, @parallel f(A::Data.Array{T}, B::Data.Array{T}, c::T) where T <: Integer = (@all(A) = @all(B)^c; return))
+                    expansion = @prettystring(1, @parallel f(A::Data.Array{T}, B::Data.Array{T}, c::<:Integer) where T <: PSNumber = (@all(A) = @all(B)^c; return))
                     @test occursin("f(A::Data.DeviceArray{T}, B::Data.DeviceArray{T},", expansion)
                 end
             end


### PR DESCRIPTION
This also contains the addition of support for keyword arguments in macros.