### PR TITLE
Fix array broadcasting error between CUDA array and host array

### DIFF
--- a/examples/diffusion3D_multigpucpu_hidecomm.jl
+++ b/examples/diffusion3D_multigpucpu_hidecomm.jl
@@ -56,7 +56,7 @@ dt = min(dx^2,dy^2,dz^2)*cp_min/lam/8.1;                                        
 for it = 1:nt
     if (it == 11) tic(); end                                                              # Start measuring time.
     if mod(it, 1000) == 1                                                                 # Visualize only every 1000th time step
-        T_nohalo .= T[2:end-1,2:end-1,2:end-1];                                           # Copy data to CPU removing the halo.
+        T_nohalo .= Array(T[2:end-1,2:end-1,2:end-1]);                                    # Copy data to CPU removing the halo.
         gather!(T_nohalo, T_v)                                                            # Gather data on process 0 (could be interpolated/sampled first)
         if (me==0) heatmap(transpose(T_v[:,ny_v÷2,:]), aspect_ratio=1); frame(anim); end  # Visualize it on process 0.
     end

--- a/miniapps/acoustic_waves_multixpu/acoustic3D_multixpu.jl
+++ b/miniapps/acoustic_waves_multixpu/acoustic3D_multixpu.jl
@@ -68,7 +68,7 @@ end
         t = t + dt
         # Visualisation
         if mod(it,nout)==0
-            P_inn .= P[2:end-1,2:end-1,2:end-1]; gather!(P_inn, P_v)
+            P_inn .= Array(P[2:end-1,2:end-1,2:end-1]); gather!(P_inn, P_v)
             if (me==0) heatmap(Xi_g, Zi_g, P_v[:,y_sl,:]', aspect_ratio=1, xlims=(Xi_g[1],Xi_g[end]), ylims=(Zi_g[1],Zi_g[end]), c=:viridis, title="Pressure"); frame(anim) end
         end
     end

--- a/miniapps/stokes_multixpu/Stokes3D_multixpu.jl
+++ b/miniapps/stokes_multixpu/Stokes3D_multixpu.jl
@@ -180,9 +180,9 @@ end
     T_eff    = A_eff/wtime_it                          # Effective memory throughput [GB/s]
     if (me==0) @printf("Total steps = %d, err = %1.3e, time = %1.3e sec (@ T_eff = %1.2f GB/s) \n", niter, err, wtime, round(T_eff, sigdigits=2)) end
     # Visualisation
-    Pt_inn .= inn(Pt);   gather!(Pt_inn, Pt_v)
-    Vz_inn .= av_zi(Vz); gather!(Vz_inn, Vz_v)
-    Rz_inn .= av_za(Rz); gather!(Rz_inn, Rz_v)
+    Pt_inn .= Array(inn(Pt));   gather!(Pt_inn, Pt_v)
+    Vz_inn .= Array(av_zi(Vz)); gather!(Vz_inn, Vz_v)
+    Rz_inn .= Array(av_za(Rz)); gather!(Rz_inn, Rz_v)
     if (me==0)
         p1 = heatmap(Xi_g, Zi_g, Pt_v[:,y_sl,:]', aspect_ratio=1, xlims=(Xi_g[1],Xi_g[end]), zlims=(Zi_g[1],Zi_g[end]), c=:inferno, title="Pressure")
         p2 = heatmap(Xi_g, Zi_g, Vz_v[:,y_sl,:]', aspect_ratio=1, xlims=(Xi_g[1],Xi_g[end]), zlims=(Zi_g[1],Zi_g[end]), c=:inferno, title="Vz")


### PR DESCRIPTION
Broadcasting a CuArray into a host Array now requires explicit conversion, `my_HostArray .= Array(my_CuArray)`. Closes #51.