### PR TITLE
Multithreaded array initialization

### DIFF
--- a/examples/diffusion3D_novis_noperf.jl
+++ b/examples/diffusion3D_novis_noperf.jl
@@ -1,14 +1,10 @@
-using ThreadPinning
-pinthreads(:spread)
-const USE_GPU = false
+const USE_GPU = true
 using ParallelStencil
 using ParallelStencil.FiniteDifferences3D
 @static if USE_GPU
     @init_parallel_stencil(CUDA, Float64, 3);
 else
     @init_parallel_stencil(Threads, Float64, 3);
-    @show Threads.nthreads()
-    @show ThreadPinning.getcpuids()
 end
 
 @parallel function diffusion3D_step!(T2, T, Ci, lam, dt, dx, dy, dz)
@@ -50,5 +46,4 @@ end
 
 end
 
-@time diffusion3D();
-@time diffusion3D();
+diffusion3D()


### PR DESCRIPTION
For better performance on systems with multiple NUMA domains. See my extensive [comment on discourse](https://discourse.julialang.org/t/poor-scaling-results-with-implicitglobalgrid-jl/65170/24).

With this PR, I get about 40% speedup for [this example](https://github.com/omlins/ParallelStencil.jl/blob/main/examples/diffusion3D_novis_noperf.jl) (with `USE_GPU=false`) when using a full AMD Zen3 CPU (64 cores, 4 NUMA domains) of [Noctua 2](https://pc2.uni-paderborn.de/hpc-services/available-systems/noctua2). 

Timings (s) before
```
╭───────────┬─────────┬─────────┬─────────╮
│ # Threads │       1 │       8 │      64 │
├───────────┼─────────┼─────────┼─────────┤
│   compact │ 12.8708 │ 2.42357 │ 2.43713 │
│    spread │ 12.8708 │ 2.38331 │  3.3897 │
╰───────────┴─────────┴─────────┴─────────╯
```

Timings (s) after
```
╭───────────┬─────────┬─────────┬─────────╮
│ # Threads │       1 │       8 │      64 │
├───────────┼─────────┼─────────┼─────────┤
│   compact │ 12.8762 │ 2.41895 │ 1.51899 │
│    spread │ 12.8762 │ 2.35042 │ 2.08579 │
╰───────────┴─────────┴─────────┴─────────╯
```

Speedup in %
```
╭───────────┬─────┬─────┬──────╮
│ # Threads │   1 │   8 │   64 │
├───────────┼─────┼─────┼──────┤
│   compact │ 0.0 │ 0.0 │ 38.0 │
│    spread │ 0.0 │ 1.0 │ 38.0 │
╰───────────┴─────┴─────┴──────╯
```

**NOTES:**
* We see that the changes have essentially no impact on the single threaded case but give speedups when run with many threads (on a multi-NUMA domain system).
* We see that if we stay within one NUMA domain (e.g. 8 threads) we don't observe a speedup (as expected).
* **compact** and **spread** indicate the [thread pinning strategy](https://carstenbauer.github.io/ThreadPinning.jl/dev/refs/api/#ThreadPinning.pinthreads-Tuple{Symbol}).
* Ideally, the access pattern of the parallel initialization should match the access pattern of the stencil as much as possible. In this PR, I just do the "trivial" parallel initialization. (In principle, one could think about passing the custom user kernel to `@zeros` and co, analyze its structure and then initialize "accordingly". But that's difficult...)

cc @luraess @omlins 

PS: Working on it at the GPU4GEO Hackathon in the Schwarzwald 😉