### PR TITLE
Treat explicit parallel indices as aliases to INDICES

### DIFF
--- a/src/ParallelKernel/parallel.jl
+++ b/src/ParallelKernel/parallel.jl
@@ -157,6 +157,11 @@ function parallel_kernel(package::Symbol, numbertype::DataType, indices::Union{S
     indices = extract_tuple(indices)
     body = get_body(kernel)
     body = remove_return(body)
+    if !all(indices .== INDICES[1:length(indices)])
+        indices_aliases = indices
+        indices = INDICES[1:length(indices)]
+        body = substitute(body, indices_aliases, indices)
+    end
     if isgpu(package)
         kernel = substitute(kernel, :(Data.Array),      :(Data.DeviceArray))
         kernel = substitute(kernel, :(Data.Cell),       :(Data.DeviceCell))

--- a/src/ParallelKernel/parallel.jl
+++ b/src/ParallelKernel/parallel.jl
@@ -42,7 +42,7 @@ const PARALLEL_INDICES_DOC = """
 Declare the `kernel` parallel and generate the given parallel `indices` inside the `kernel` using the package for parallelization selected with [`@init_parallel_kernel`](@ref).
 """
 @doc PARALLEL_INDICES_DOC
-macro parallel_indices(args...) check_initialized(); checkargs_parallel_indices(args...); esc(parallel_indices(args...)); end
+macro parallel_indices(args...) check_initialized(); checkargs_parallel_indices(args...); esc(parallel_indices(__module__, args...)); end
 
 
 ##
@@ -85,9 +85,9 @@ macro synchronize(args...) check_initialized(); esc(synchronize(args...)); end
 macro parallel_cuda(args...)            check_initialized(); checkargs_parallel(args...); esc(parallel(__module__, args...; package=PKG_CUDA)); end
 macro parallel_amdgpu(args...)          check_initialized(); checkargs_parallel(args...); esc(parallel(__module__, args...; package=PKG_AMDGPU)); end
 macro parallel_threads(args...)         check_initialized(); checkargs_parallel(args...); esc(parallel(__module__, args...; package=PKG_THREADS)); end
-macro parallel_indices_cuda(args...)    check_initialized(); checkargs_parallel_indices(args...); esc(parallel_indices(args...; package=PKG_CUDA)); end
-macro parallel_indices_amdgpu(args...)  check_initialized(); checkargs_parallel_indices(args...); esc(parallel_indices(args...; package=PKG_AMDGPU)); end
-macro parallel_indices_threads(args...) check_initialized(); checkargs_parallel_indices(args...); esc(parallel_indices(args...; package=PKG_THREADS)); end
+macro parallel_indices_cuda(args...)    check_initialized(); checkargs_parallel_indices(args...); esc(parallel_indices(__module__, args...; package=PKG_CUDA)); end
+macro parallel_indices_amdgpu(args...)  check_initialized(); checkargs_parallel_indices(args...); esc(parallel_indices(__module__, args...; package=PKG_AMDGPU)); end
+macro parallel_indices_threads(args...) check_initialized(); checkargs_parallel_indices(args...); esc(parallel_indices(__module__, args...; package=PKG_THREADS)); end
 macro parallel_async_cuda(args...)      check_initialized(); checkargs_parallel(args...); esc(parallel_async(__module__, args...; package=PKG_CUDA)); end
 macro parallel_async_amdgpu(args...)    check_initialized(); checkargs_parallel(args...); esc(parallel_async(__module__, args...; package=PKG_AMDGPU)); end
 macro parallel_async_threads(args...)   check_initialized(); checkargs_parallel(args...); esc(parallel_async(__module__, args...; package=PKG_THREADS)); end
@@ -136,9 +136,9 @@ function parallel(caller::Module, args::Union{Symbol,Expr}...; package::Symbol=g
     end
 end
 
-function parallel_indices(args::Union{Symbol,Expr}...; package::Symbol=get_package())
+function parallel_indices(caller::Module, args::Union{Symbol,Expr}...; package::Symbol=get_package())
     numbertype = get_numbertype()
-    parallel_kernel(package, numbertype, args...)
+    parallel_kernel(caller, package, numbertype, args...)
 end
 
 function synchronize(args::Union{Symbol,Expr}...; package::Symbol=get_package())
@@ -152,13 +152,13 @@ end
 
 ## @PARALLEL KERNEL FUNCTIONS
 
-function parallel_kernel(package::Symbol, numbertype::DataType, indices::Union{Symbol,Expr}, kernel::Expr)
+function parallel_kernel(caller::Module, package::Symbol, numbertype::DataType, indices::Union{Symbol,Expr}, kernel::Expr)
     if (!isa(indices,Symbol) && !isa(indices.head,Symbol)) @ArgumentError("@parallel_indices: argument 'indices' must be a tuple of indices or a single index (e.g. (ix, iy, iz) or (ix, iy) or ix ).") end
     indices = extract_tuple(indices)
     body = get_body(kernel)
     body = remove_return(body)
     use_aliases = !all(indices .== INDICES[1:length(indices)])
-    if use_aliases
+    if use_aliases # NOTE: we treat explicit parallel indices as aliases to the statically retrievable indices INDICES.
         indices_aliases = indices
         indices = [INDICES[1:length(indices)]...]
         for i=1:length(indices_aliases)

--- a/src/ParallelKernel/parallel.jl
+++ b/src/ParallelKernel/parallel.jl
@@ -161,7 +161,9 @@ function parallel_kernel(package::Symbol, numbertype::DataType, indices::Union{S
     if use_aliases
         indices_aliases = indices
         indices = [INDICES[1:length(indices)]...]
-        body = substitute(body, indices_aliases, indices)
+        for i=1:length(indices_aliases)
+            body = substitute(body, indices_aliases[i], indices[i])
+        end
     end
     if isgpu(package)
         kernel = substitute(kernel, :(Data.Array),      :(Data.DeviceArray))
@@ -195,7 +197,9 @@ function parallel_kernel(package::Symbol, numbertype::DataType, indices::Union{S
     # @show QuoteNode(simplify_varnames!(remove_linenumbernodes!(deepcopy(kernel))))
     if use_aliases
         kernel = macroexpand(caller, kernel)
-        kernel = substitute(kernel, indices_aliases, indices)
+        for i=1:length(indices_aliases)
+            kernel = substitute(kernel, indices[i], indices_aliases[i])
+        end
     end
     return kernel
 end

--- a/src/ParallelKernel/parallel.jl
+++ b/src/ParallelKernel/parallel.jl
@@ -157,7 +157,8 @@ function parallel_kernel(package::Symbol, numbertype::DataType, indices::Union{S
     indices = extract_tuple(indices)
     body = get_body(kernel)
     body = remove_return(body)
-    if !all(indices .== INDICES[1:length(indices)])
+    use_aliases = !all(indices .== INDICES[1:length(indices)])
+    if use_aliases
         indices_aliases = indices
         indices = [INDICES[1:length(indices)]...]
         body = substitute(body, indices_aliases, indices)
@@ -192,6 +193,10 @@ function parallel_kernel(package::Symbol, numbertype::DataType, indices::Union{S
     body = add_return(body)
     set_body!(kernel, body)
     # @show QuoteNode(simplify_varnames!(remove_linenumbernodes!(deepcopy(kernel))))
+    if use_aliases
+        kernel = macroexpand(caller, kernel)
+        kernel = substitute(kernel, indices_aliases, indices)
+    end
     return kernel
 end
 

--- a/src/ParallelKernel/parallel.jl
+++ b/src/ParallelKernel/parallel.jl
@@ -159,7 +159,7 @@ function parallel_kernel(package::Symbol, numbertype::DataType, indices::Union{S
     body = remove_return(body)
     if !all(indices .== INDICES[1:length(indices)])
         indices_aliases = indices
-        indices = INDICES[1:length(indices)]
+        indices = [INDICES[1:length(indices)]...]
         body = substitute(body, indices_aliases, indices)
     end
     if isgpu(package)

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -156,7 +156,7 @@ function parallel_indices(source::LineNumberNode, caller::Module, args::Union{Sy
             $metadata_function
         end
     else
-        ParallelKernel.parallel_indices(posargs...; package=package)
+        ParallelKernel.parallel_indices(caller, posargs...; package=package)
     end
 end
 


### PR DESCRIPTION
Both ways of writing macros shown in the following are supported for usage in `@parallel_indices`:
```julia
macro compute(A)              esc(:($(INDICES[1]) + ($(INDICES[2])-1)*size($A,1))) end
macro compute_with_aliases(A) esc(:(ix            + (iz           -1)*size($A,1))) end

@parallel_indices (ix,iz) function write_indices!(A)
    A[ix,end,iz] = @compute_with_aliases(A);
    return
end

@parallel_indices (ix,iz) function write_indices!(A)
    A[ix,end,iz] = @compute(A);
    return
end
```