### PR TITLE
Allow for return statements in nested functions within parallel kernels

### DIFF
--- a/src/ParallelKernel/parallel.jl
+++ b/src/ParallelKernel/parallel.jl
@@ -156,7 +156,7 @@ function parallel_kernel(caller::Module, package::Symbol, numbertype::DataType, 
     if (!isa(indices,Symbol) && !isa(indices.head,Symbol)) @ArgumentError("@parallel_indices: argument 'indices' must be a tuple of indices or a single index (e.g. (ix, iy, iz) or (ix, iy) or ix ).") end
     indices = extract_tuple(indices)
     body = get_body(kernel)
-    body = remove_return(body)
+    body = remove_returns(body)
     use_aliases = !all(indices .== INDICES[1:length(indices)])
     if use_aliases # NOTE: we treat explicit parallel indices as aliases to the statically retrievable indices INDICES.
         indices_aliases = indices

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -1,4 +1,4 @@
-import .ParallelKernel: get_name, set_name, get_body, set_body!, add_return, remove_return, extract_kwargs, split_parallel_args, extract_tuple, substitute, literaltypes, push_to_signature!, add_loop, add_threadids, promote_maxsize
+import .ParallelKernel: get_name, set_name, get_body, set_body!, add_return, remove_returns, extract_kwargs, split_parallel_args, extract_tuple, substitute, literaltypes, push_to_signature!, add_loop, add_threadids, promote_maxsize
 
 const PARALLEL_DOC = """
     @parallel kernel
@@ -185,7 +185,7 @@ function parallel_indices_memopt(metadata_module::Module, metadata_function::Exp
     if (!isa(indices,Symbol) && !isa(indices.head,Symbol)) @ArgumentError("@parallel_indices: argument 'indices' must be a tuple of indices, a single index or a variable followed by the splat operator representing a tuple of indices (e.g. (ix, iy, iz) or (ix, iy) or ix or I...).") end
     if (!isa(optvars,Symbol) && !isa(optvars.head,Symbol)) @ArgumentError("@parallel_indices: argument 'optvars' must be a tuple of optvars or a single optvar (e.g. (A, B, C) or A ).") end
     body = get_body(kernel)
-    body = remove_return(body)
+    body = remove_returns(body)
     body = add_memopt(metadata_module, is_parallel_kernel, caller, package, body, indices, optvars, loopdim, loopsize, optranges, useshmemhalos, optimize_halo_read)
     body = add_return(body)
     set_body!(kernel, body)
@@ -198,7 +198,7 @@ function parallel_kernel(metadata_module::Module, metadata_function::Expr, calle
     memopt = haskey(kwargs, :memopt) ? kwargs.memopt : get_memopt()
     indices = get_indices_expr(ndims).args
     body = get_body(kernel)
-    body = remove_return(body)
+    body = remove_returns(body)
     validate_body(body)
     kernelargs = splitarg.(extract_kernel_args(kernel)[1])
     argvars = (arg[1] for arg in kernelargs)

--- a/test/ParallelKernel/test_parallel.jl
+++ b/test/ParallelKernel/test_parallel.jl
@@ -203,7 +203,7 @@ macro compute_with_aliases(A) esc(:(ix            + (iz           -1)*size($A,1)
                     @parallel (1:size(A,1), 1:size(A,3)) write_indices!(A);
                     @test all(Array(A)[:,end,:] .== [ix + (iz-1)*size(A,1) for ix=1:size(A,1), iz=1:size(A,3)])
                 end;
-                @testset "function closure (long definition, array modification)" begin
+                @testset "nested function (long definition, array modification)" begin
                     A  = @zeros(4, 5, 6)
                     @parallel_indices (ix,iy,iz) function write_indices!(A)
                         function compute_indices!(A)
@@ -216,7 +216,7 @@ macro compute_with_aliases(A) esc(:(ix            + (iz           -1)*size($A,1)
                     @parallel write_indices!(A);
                     @test all(Array(A) .== [ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2) for ix=1:size(A,1), iy=1:size(A,2), iz=1:size(A,3)])
                 end;
-                @testset "function closure (short definition, array modification)" begin
+                @testset "nested function (short definition, array modification)" begin
                     A  = @zeros(4, 5, 6)
                     @parallel_indices (ix,iy,iz) function write_indices!(A)
                         compute_indices!(A) = (A[ix,iy,iz] = ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2); return)
@@ -226,7 +226,7 @@ macro compute_with_aliases(A) esc(:(ix            + (iz           -1)*size($A,1)
                     @parallel write_indices!(A);
                     @test all(Array(A) .== [ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2) for ix=1:size(A,1), iy=1:size(A,2), iz=1:size(A,3)])
                 end;
-                @testset "function closure (long definition, return value)" begin
+                @testset "nested function (long definition, return value)" begin
                     A  = @zeros(4, 5, 6)
                     @parallel_indices (ix,iy,iz) function write_indices!(A)
                         function compute_indices(A)
@@ -238,7 +238,7 @@ macro compute_with_aliases(A) esc(:(ix            + (iz           -1)*size($A,1)
                     @parallel write_indices!(A);
                     @test all(Array(A) .== [ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2) for ix=1:size(A,1), iy=1:size(A,2), iz=1:size(A,3)])
                 end;
-                @testset "function closure (short definition, return value)" begin
+                @testset "nested function (short definition, return value)" begin
                     A  = @zeros(4, 5, 6)
                     @parallel_indices (ix,iy,iz) function write_indices!(A)
                         compute_indices(A) = return ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2)


### PR DESCRIPTION
This enables the following for example:
```julia
                @testset "nested function (long definition, array modification)" begin
                    A  = @zeros(4, 5, 6)
                    @parallel_indices (ix,iy,iz) function write_indices!(A)
                        function compute_indices!(A)
                            A[ix,iy,iz] = ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2);
                            return
                        end
                        compute_indices!(A)
                        return
                    end
                    @parallel write_indices!(A);
                    @test all(Array(A) .== [ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2) for ix=1:size(A,1), iy=1:size(A,2), iz=1:size(A,3)])
                end;
                @testset "nested function (short definition, array modification)" begin
                    A  = @zeros(4, 5, 6)
                    @parallel_indices (ix,iy,iz) function write_indices!(A)
                        compute_indices!(A) = (A[ix,iy,iz] = ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2); return)
                        compute_indices!(A)
                        return
                    end
                    @parallel write_indices!(A);
                    @test all(Array(A) .== [ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2) for ix=1:size(A,1), iy=1:size(A,2), iz=1:size(A,3)])
                end;
                @testset "nested function (long definition, return value)" begin
                    A  = @zeros(4, 5, 6)
                    @parallel_indices (ix,iy,iz) function write_indices!(A)
                        function compute_indices(A)
                            return ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2)
                        end
                        A[ix,iy,iz] = compute_indices(A)
                        return
                    end
                    @parallel write_indices!(A);
                    @test all(Array(A) .== [ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2) for ix=1:size(A,1), iy=1:size(A,2), iz=1:size(A,3)])
                end;
                @testset "nested function (short definition, return value)" begin
                    A  = @zeros(4, 5, 6)
                    @parallel_indices (ix,iy,iz) function write_indices!(A)
                        compute_indices(A) = return ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2)
                        A[ix,iy,iz] = compute_indices(A)
                        return
                    end
                    @parallel write_indices!(A);
                    @test all(Array(A) .== [ix + (iy-1)*size(A,1) + (iz-1)*size(A,1)*size(A,2) for ix=1:size(A,1), iy=1:size(A,2), iz=1:size(A,3)])
                end;
```